### PR TITLE
Translate documentation to Chinese

### DIFF
--- a/doc/ctrlp.cnx
+++ b/doc/ctrlp.cnx
@@ -74,8 +74,8 @@ OPTIONS                                                         *ctrlp-options*
   |ctrlp_use_migemo|............为日语文件名启用Migemo模式。
   |ctrlp_prompt_mappings|.......改变提示符面板内部的按键绑定。
 
-  最近最常使用模式:
-  |ctrlp_mruf_max|..............记录的最近最常最多使用的最大数据。
+  最近最多使用模式:
+  |ctrlp_mruf_max|..............记录的最近最多使用的最大数据。
   |ctrlp_mruf_exclude|..........需要被排除的文件。
   |ctrlp_mruf_include|..........需要被记录的文件。
   |ctrlp_mruf_relative|.........只显示在工作目录内的最近最多使用。
@@ -218,7 +218,7 @@ OPTIONS                                                         *ctrlp-options*
 注意: 当在CtrlP中时你可以使用 <F5> 来快速的清除缓存。
 
                                                 *'g:ctrlp_clear_cache_on_exit'*
-设置该选项为0通过退出Vim时不删除缓存文件来启用跨回话的缓存: >
+设置该选项为0通过退出Vim时不删除缓存文件来启用跨会话的缓存: >
   let g:ctrlp_clear_cache_on_exit = 1
 <
 


### PR DESCRIPTION
From: https://github.com/kien/ctrlp.vim/pull/506

> Hello,I translate the ctrlp doc into Chinese to help Chinese people to use this amazing plugin.
> But I am not sure whether it is a proper way to add the ctrl_cn.txt under directory /doc,if you want to use a better way,please tell me how to add the Chinese version doc.
> 
> sorry，I find when the ctrlp.txt and ctrlp_cn.txt both exists,the helptags command will generate empty tags file,as most people use vundle or pathogen to manage plugins,it will be a problem,could you tell me how to solve this problem?

Comment from @kien:

> This is great. Thank you!
> 
> As for the filename, I'm not sure what the language code for Chinese is. If it's "cn" then the filename should be ctrlp.cnx.

Follow-up from @codepiano:

> Yeah，you are right,it is because the file extension,I change the filename to ctrlp.cnx,and this time the :helptags command generate file 'tags' for ctrlp.txt and generate 'tags-cn' for ctrlp.cnx.In my language environment,use ':help ctrlp' command can show the correct Chinese doc file.
> I push to this branch again.
