### PR TITLE
Tab drilling

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -715,8 +715,12 @@ fu! s:PrtExpandDir()
 	let str_tmp = str
 	if str == ''
 		 let dir = s:headfirstntail(s:fnesc(ctrlp#getcline(), 'g'))
-		 if len(dir) == 2 && dir[0] != ''
-			  let str = dir[0].s:lash()
+		 if len(dir) == 2 && dir[0] != '' && isdirectory(dir[0])
+				cal ctrlp#setdir(dir[0])
+				cal ctrlp#switchtype(0)
+				cal ctrlp#recordhist()
+				cal s:PrtClear()
+				return
 		 en
 	en
 	if str == '' | retu | en
@@ -735,7 +739,7 @@ fu! s:PrtExpandDir()
 	if str_tmp == str
 		 let slash = s:lash()
 		 let dir = s:headfirstntail(s:fnesc(ctrlp#getcline(), 'g'))
-		 if len(dir) == 2 && dir[0] != ''
+		 if len(dir) == 2 && dir[0] != '' && isdirectory(dir[0])
 			  let exp = 1
 			  while exp
 				   if str[:len(dir[0])] != dir[0]
@@ -748,7 +752,11 @@ fu! s:PrtExpandDir()
 					    break
 				   en
 			  endw
-			  let str = dir[0].slash
+				cal ctrlp#setdir(dir[0])
+				cal ctrlp#switchtype(0)
+				cal ctrlp#recordhist()
+				cal s:PrtClear()
+				return
 		 en
 	en
 	let s:prompt[0] = exists('hasat') ? hasat[0].str : str


### PR DESCRIPTION
From https://github.com/kien/ctrlp.vim/pull/513:

> This patch adds additional abilities to the tab key to expand directories based on the currently selected entry.
> 1. If the user didn't type anything, tab now expands the directory name of the selected entry. Before it didn't do anything
> 2. If the user typed something, tab now expands the directory one after the other while maintaining any other expansion that happened before

Comment from @kien:

> This looks great. But how does it interact with CtrlP's existing tab-completion? Also, since they are closely resemble, is merging them feasible?

Comment from @axelson:

> @kien how does CtrlP's existing tab-completion work? I don't see it listed in the documentation anywhere.

Comment from @kien:

> @axelson see :h ctrlp-autocompletion. You need to type something first.
