### PR TITLE
Extend PrtInsert to support multi character action

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -681,6 +681,10 @@ fu! s:PrtInsert(...)
 		let regcont = s:getregs()
 		if regcont < 0 | retu | en
 	en
+	if type =~# '^r.$'
+		let regcont = s:regisfilter(type[1])
+		let type = 'r'
+	en
 	unl! s:hstgot
 	let s:act_add = 1
 	let s:prompt[0] .= type ==# 'w' ? s:crword


### PR DESCRIPTION
From https://github.com/kien/ctrlp.vim/pull/568:

>    PrtInsert can be mapped to insert clipboard or some register.
>     This extends PrtInsert to support insert any register (e.g "b
>     register).
>    Rationale: I mostly use " (unnamed register for work) so now
> 
> ```
>     let g:ctrlp_prompt_mappings = {
>         \ 'PrtInsert("r\"")': ['<c-u>'],
>         \ }
> ```
> 
> will work.
>    ( when user enters c-u the content of unnamed register is entered)
