### PR TITLE
Add ability to specify a custom ignore function, instead of just patterns

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1532,9 +1532,17 @@ fu! ctrlp#dirnfile(entries)
 endf
 
 fu! s:usrign(item, type)
-	retu s:igntype == 1 ? a:item =~ s:usrign
-		\ : s:igntype == 4 && has_key(s:usrign, a:type) && s:usrign[a:type] != ''
-		\ ? a:item =~ s:usrign[a:type] : 0
+  if s:igntype == 1 | retu a:item =~ s:usrign | end
+  if s:igntype == 4
+    if has_key(s:usrign, a:type) && s:usrign[a:type] != ''
+          \ && a:item =~ s:usrign[a:type]
+      retu 1
+    elsei has_key(s:usrign, 'func') && s:usrign['func'] != ''
+          \ && call(s:usrign['func'], [a:item, a:type])
+      retur 1
+    end
+  end
+  retu 0
 endf
 
 fu! s:samerootsyml(each, isfile, cwd)

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -261,6 +261,9 @@ Examples: >
   let g:ctrlp_custom_ignore = {
     \ 'file': '\v(\.cpp|\.h|\.hh|\.cxx)@<!$'
     \ }
+  let g:ctrlp_custom_ignore = {
+    \ 'func': 'some#custom#match_function'
+    \ }
 <
 Note #1: by default, |wildignore| and |g:ctrlp_custom_ignore| only apply when
 |globpath()| is used to scan for files, thus these options do not apply when a
@@ -268,6 +271,12 @@ command defined with |g:ctrlp_user_command| is being used.
 
 Note #2: when changing the option's variable type, remember to |:unlet| it
 first or restart Vim to avoid the "E706: Variable type mismatch" error.
+
+Note #3: when using the "func" ignore type, you must provide the full name of
+a function that can be called from CtrlP. An |autoload| function name is
+recommended here. The function must take 2 parameters, the item to match and
+its type. The type will be "dir", "file", or "link". The function must return
+1 if the item should be ignored, 0 otherwise.
 
                                                           *'g:ctrlp_max_files'*
 The maximum number of files to scan, set to 0 for no limit: >


### PR DESCRIPTION
From https://github.com/kien/ctrlp.vim/pull/594:

> This makes it possible to customize the ignore patterns on a per-project basis... I do that by loading patterns for a given project from a ".ctrlpignore" file at the root of the project. Generally you don't need this, but for some codebases where the directory structure is not so clean, you kinda have to.

Comment from @d11wtq:

> Yes! I totally want this :)

Follow-up from @ludovicchabant:

> You may want to see how I use it with my [auto-ignore script](https://bitbucket.org/ludovicchabant/dotfiles/src/8db8c5f1fdd103184b87e220aa1ce4210e9be3b3/vim/autoload/ctrlpext/autoignore.vim?at=default) (you just need to activate it with a `ctrlpext#autoignore#init()` in your vimrc) and an example of a [`.ctrlpignore file`](https://bitbucket.org/ludovicchabant/dotfiles/src/8db8c5f1fdd103184b87e220aa1ce4210e9be3b3/.ctrlpignore?at=default). Cheers :)
> 
> (after I play around with it more, I may release that auto-ignore script as a standalone Vim plugin)

Comment from @ludovicchabant:

> Also, it's not very optimal right now (1 map lookup + 1 regex match per directory). I'll need to modify some more CtrlP code to fix that (probably some "before/after scan" hooks, so I can do only 1 map lookup for the whole project).
