### PR TITLE
Drop migemo

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -87,7 +87,6 @@ let [s:pref, s:bpref, s:opts, s:new_opts, s:lc_opts] =
 	\ 'status_func':           ['s:status', {}],
 	\ 'tabpage_position':      ['s:tabpage', 'ac'],
 	\ 'use_caching':           ['s:caching', 1],
-	\ 'use_migemo':            ['s:migemo', 0],
 	\ 'user_command':          ['s:usrcmd', ''],
 	\ 'working_path_mode':     ['s:pathmode', 'ra'],
 	\ }, {
@@ -499,9 +498,6 @@ endf
 
 fu! s:SplitPattern(str)
 	let str = a:str
-	if s:migemo && s:regexp && len(str) > 0 && executable('cmigemo')
-		let str = s:migemo(str)
-	en
 	let s:savestr = str
 	if s:regexp
 		let pat = s:regexfilter(str)
@@ -1946,22 +1942,6 @@ fu! s:getinput(...)
 		en
 	en
 	retu spi == 'c' ? prt[0] : join(prt, '')
-endf
-
-fu! s:migemo(str)
-	let [str, rtp] = [a:str, s:fnesc(&rtp, 'g')]
-	let dict = s:glbpath(rtp, printf("dict/%s/migemo-dict", &enc), 1)
-	if !len(dict)
-		let dict = s:glbpath(rtp, "dict/migemo-dict", 1)
-	en
-	if len(dict)
-		let [tokens, str, cmd] = [split(str, '\s'), '', 'cmigemo -v -w %s -d %s']
-		for token in tokens
-			let rtn = system(printf(cmd, shellescape(token), shellescape(dict)))
-			let str .= !v:shell_error && strlen(rtn) > 0 ? '.*'.rtn : token
-		endfo
-	en
-	retu str
 endf
 
 fu! s:strwidth(str)

--- a/doc/ctrlp.cnx
+++ b/doc/ctrlp.cnx
@@ -71,7 +71,6 @@ OPTIONS                                                         *ctrlp-options*
   |ctrlp_default_input|.........为提示符面板提供一个种子。
   |ctrlp_abbrev|................输入缩写。
   |ctrlp_key_loop|..............为多字节输入开启输入事件循环。
-  |ctrlp_use_migemo|............为日语文件名启用Migemo模式。
   |ctrlp_prompt_mappings|.......改变提示符面板内部的按键绑定。
 
   最近最多使用模式:
@@ -477,12 +476,6 @@ OPTIONS                                                         *ctrlp-options*
 
 注意 #2: 你可以在提示符面板使用自定义的按键绑定切换这个特性: >
   let g:ctrlp_prompt_mappings = { 'ToggleKeyLoop()': ['<F3>'] }
-<
-
-                                                         *'g:ctrlp_use_migemo'*
-设置该选项为1将为日文文件名使用Migemo模式。Migemo搜索只在正则模式下有效。 使
-用空格分割单词来分离模式: >
-  let g:ctrlp_use_migemo = 0
 <
 
                                                     *'g:ctrlp_prompt_mappings'*

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -63,7 +63,6 @@ Overview:~
   |ctrlp_default_input|.........Seed the prompt with an initial string.
   |ctrlp_abbrev|................Input abbreviations.
   |ctrlp_key_loop|..............Use input looping for multi-byte input.
-  |ctrlp_use_migemo|............Use Migemo patterns for Japanese filenames.
   |ctrlp_prompt_mappings|.......Change the mappings inside the prompt.
 
   MRU mode:
@@ -495,12 +494,6 @@ Note #1: when set, this option resets the |g:ctrlp_lazy_update| option.
 
 Note #2: you can toggle this feature inside the prompt with a custom mapping: >
   let g:ctrlp_prompt_mappings = { 'ToggleKeyLoop()': ['<F3>'] }
-<
-
-                                                         *'g:ctrlp_use_migemo'*
-Set this to 1 to use Migemo Pattern for Japanese filenames. Migemo Search only
-works in regexp mode. To split the pattern, separate words with space: >
-  let g:ctrlp_use_migemo = 0
 <
 
                                                     *'g:ctrlp_prompt_mappings'*


### PR DESCRIPTION
migemo is a grep-like filter tool. And there is [migemogrep](https://github.com/peco/migemogrep) that is possible to use like grep instead of generating regexp pattern by cmigemo.
So I decided to drop migemo part from ctrlp.vim
