### PR TITLE
New buffer explorer mode with highlighting and more

### DIFF
--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -960,8 +960,12 @@ Function keys:~
     - Remove deleted files from the MRU list.
 
   <F7>
-    - Wipe the MRU list.
-    - Delete MRU entries marked by <c-z>.
+    MRU mode:
+    - Wipe the list.
+    - Delete entries marked by <c-z>.
+    Buffer mode:
+    - Delete entry under the cursor or delete multiple entries marked by <c-z>.
+
 
 Pasting:~
 
@@ -1196,6 +1200,17 @@ Highlighting:~
     CtrlPPrtText   : the prompt's text (|hl-Normal|)
     CtrlPPrtCursor : the prompt's cursor when moving over the text (Constant)
 
+  * Buffer explorer mode:
+    CtrlPBufferNr     : buffer number
+    CtrlPBufferInd    : '+' and '#' indicators (see |:buffers|)
+    CtrlPBufferHid    : hidden buffer
+    CtrlPBufferHidMod : hidden and modified buffer
+    CtrlPBufferVis    : visible buffer
+    CtrlPBufferVisMod : visible and modified buffer
+    CtrlPBufferCur    : current buffer
+    CtrlPBufferCurMod : current and modified buffer
+    CtrlPBufferPath   : buffer path
+
   * In extensions:
     CtrlPTabExtra  : the part of each line that's not matched against (Comment)
     CtrlPBufName   : the buffer name an entry belongs to (|hl-Directory|)
@@ -1297,10 +1312,11 @@ Special thanks:~
     * Jo De Boeck <github.com/grimpy>
     * Rudi Grinberg <github.com/rgrinberg>
     * Timothy Mellor <github.com/mellort>
+    * Sergey Vlasov <github.com/sergey-vlasov>
 
 ===============================================================================
 CHANGELOG                                                     *ctrlp-changelog*
-
+    + New buffer explorer mode with highlighting (|+conceal| recommended)
     + Combine *g:ctrlp_match_window_bottom* *g:ctrlp_match_window_reversed* and
       *g:ctrlp_max_height* into |g:ctrlp_match_window|.
     + New option: |g:ctrlp_match_window|.


### PR DESCRIPTION
Integration of [ctrlp-hibuff](https://github.com/sergey-vlasov/ctrlp-hibuff) as [requested](https://github.com/sergey-vlasov/ctrlp-hibuff/issues/1).

The new buffer explorer replaces the original functionality and adds new things as:
- Highlighting of everything (buffer name for each buffer state, buffer numbers etc.)
- Showing buffer numbers and paths
- Quick match by modified buffers using `+` indicator, matching by buffer number or name
- Single/multiple buffer deletion (like in MRU mode via F7)
