### PR TITLE
Add Option to exclude nonmodifiable buffers from MRU

### DIFF
--- a/autoload/ctrlp/mrufiles.vim
+++ b/autoload/ctrlp/mrufiles.vim
@@ -15,6 +15,7 @@ fu! ctrlp#mrufiles#opts()
 		\ 'case_sensitive': ['s:cseno', 1],
 		\ 'relative': ['s:re', 0],
 		\ 'save_on_update': ['s:soup', 1],
+		\ 'exclude_nomod': ['s:exclnomod', 0],
 		\ }]
 	for [ke, va] in items(opts)
 		let [{va[0]}, {pref.ke}] = [pref.ke, exists(pref.ke) ? {pref.ke} : va[1]]
@@ -55,6 +56,8 @@ fu! s:reformat(mrufs, ...)
 endf
 
 fu! s:record(bufnr)
+	if s:exclnomod && &l:modifiable | retu | en
+	if s:exclnomod && !&l:modifiable | retu | en
 	if s:locked | retu | en
 	let bufnr = a:bufnr + 0
 	let bufname = bufname(bufnr)
@@ -143,7 +146,7 @@ fu! ctrlp#mrufiles#init()
 	let s:locked = 0
 	aug CtrlPMRUF
 		au!
-		au BufAdd,BufEnter,BufLeave,BufWritePost * cal s:record(expand('<abuf>', 1))
+		au BufWinEnter * cal s:record(expand('<abuf>', 1))
 		au QuickFixCmdPre  *vimgrep* let s:locked = 1
 		au QuickFixCmdPost *vimgrep* let s:locked = 0
 		au VimLeavePre * cal s:savetofile(s:mergelists())

--- a/autoload/ctrlp/mrufiles.vim
+++ b/autoload/ctrlp/mrufiles.vim
@@ -146,7 +146,7 @@ fu! ctrlp#mrufiles#init()
 	let s:locked = 0
 	aug CtrlPMRUF
 		au!
-		au BufWinEnter,BufWinLeave * cal s:record(expand('<abuf>', 1))
+		au BufWinEnter,BufWinLeave,BufWritePost * cal s:record(expand('<abuf>', 1))
 		au QuickFixCmdPre  *vimgrep* let s:locked = 1
 		au QuickFixCmdPost *vimgrep* let s:locked = 0
 		au VimLeavePre * cal s:savetofile(s:mergelists())

--- a/autoload/ctrlp/mrufiles.vim
+++ b/autoload/ctrlp/mrufiles.vim
@@ -146,7 +146,7 @@ fu! ctrlp#mrufiles#init()
 	let s:locked = 0
 	aug CtrlPMRUF
 		au!
-		au BufWinEnter * cal s:record(expand('<abuf>', 1))
+		au BufWinEnter,BufWinLeave * cal s:record(expand('<abuf>', 1))
 		au QuickFixCmdPre  *vimgrep* let s:locked = 1
 		au QuickFixCmdPost *vimgrep* let s:locked = 0
 		au VimLeavePre * cal s:savetofile(s:mergelists())

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -73,6 +73,7 @@ Overview:~
   |ctrlp_mruf_default_order|....Disable sorting.
   |ctrlp_mruf_case_sensitive|...MRU files are case sensitive or not.
   |ctrlp_mruf_save_on_update|...Save to disk whenever a new entry is added.
+  |ctrlp_mruf_exclude_nomod|....Exclude nonmodifiable buffers from the MRU list.
 
   BufferTag mode: (to enable, see |ctrlp-extensions|)
   |g:ctrlp_buftag_ctags_bin|....The location of the ctags-compatible binary.
@@ -600,6 +601,11 @@ entry is added, saving will then only occur when exiting Vim: >
   let g:ctrlp_mruf_save_on_update = 1
 <
 
+                                                *'g:ctrlp_mruf_exclude_nomod*
+Set this to 1 to disable adding nonmodifiable buffers, for example help files,
+to the MRU list: >
+let g:ctrlp_mruf_exclude_nomod = 0
+<
 ----------------------------------------
 Advanced options:~
 


### PR DESCRIPTION
For example, when searching for .txt the MRU is crammed by recent accesses to the VIM doc by K. With this addtitional option g:ctrlp_mruf_exclude_nomod, these files, as well as all other nonmodifiable buffers are no longer added to the MRU list.

I also cleaned up the autocmd events for the MRU list. Please check that it suits you. Regardless, the BufWinEnter autocmd is crucial to check at the right time if the buffer is nonmodifiable.