### PR TITLE
Center the screen on the tag after jumping.

### DIFF
--- a/autoload/ctrlp/tag.vim
+++ b/autoload/ctrlp/tag.vim
@@ -121,6 +121,7 @@ fu! ctrlp#tag#accept(mode, str)
 		en
 		cal feedkeys(":".cmd." ".tg."\r".ext, 'nt')
 	en
+	cal feedkeys('zvzz', 'nt')
 	cal ctrlp#setlcdir()
 endf
 


### PR DESCRIPTION
This also makes the behavior consistent with buffertag, changes, and
quickfix.  It originally used `sil! norm! zvzz`, just as the others do,
but that didn't play well with the use of `feedkeys()` in
`ctrlp#tag#accept()`.  Instead, we now use `feedkeys()` to do the
centering.
