### PR TITLE
Fixes issue #38: switch_buffer not working properly

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1000,7 +1000,7 @@ fu! ctrlp#acceptfile(...)
 	cal s:PrtExit()
 	let tail = s:tail()
 	let j2l = atl != '' ? atl : matchstr(tail, '^ +\zs\d\+$')
-	if ( s:jmptobuf =~ md || ( strlen(s:jmptobuf) && s:jmptobuf !~# '\v^0$' && md =~ '[et]' ) ) && bufnr > 0
+	if ( s:jmptobuf =~ md || ( !empty(s:jmptobuf) && s:jmptobuf !~# '\v^0$' && md =~ '[et]' ) ) && bufnr > 0
 		\ && !( md == 'e' && bufnr == bufnr('%') )
 		let [jmpb, bufwinnr] = [1, bufwinnr(bufnr)]
 		let buftab = ( s:jmptobuf =~# '[tTVH]' || s:jmptobuf > 1 )


### PR DESCRIPTION
To duplicate issue:

```
let g:ctrlp_switch_buffer = 'Et'
```

in .vimrc.

Open new Vim instance, edit file A. Edit file B in new tab. Call :CtrlPBuffer, and select file A. Buffer will open in second tab instead of switching to first tab.

This fixes the bug which is caused by bad type conversion.
