### PR TITLE
Initialize callback for custom ignore func

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -343,6 +343,7 @@ fu! ctrlp#files()
 		" Get the list of files
 		if empty(lscmd)
 			if !ctrlp#igncwd(s:dyncwd)
+				cal s:InitCustomFuncs()
 				cal s:GlobPath(s:fnesc(s:dyncwd, 'g', ','), 0)
 			en
 		el
@@ -367,6 +368,12 @@ fu! ctrlp#files()
 	en
 	cal extend(s:ficounts, { s:dyncwd : [len(g:ctrlp_allfiles), catime] })
 	retu g:ctrlp_allfiles
+endf
+
+fu! s:InitCustomFuncs()
+	if has_key(s:usrign, 'func-init') && s:usrign['func-init'] != ''
+		exe call(s:usrign['func-init'], [])
+	en
 endf
 
 fu! s:GlobPath(dirs, depth)

--- a/autoload/ctrlp/buffertag.vim
+++ b/autoload/ctrlp/buffertag.vim
@@ -73,6 +73,7 @@ let s:types = {
 	\ 'sh'     : '%ssh%ssh%sf',
 	\ 'csh'    : '%ssh%ssh%sf',
 	\ 'zsh'    : '%ssh%ssh%sf',
+	\ 'scala'  : '%sscala%sscala%sctTmlp',
 	\ 'slang'  : '%sslang%sslang%snf',
 	\ 'sml'    : '%ssml%ssml%secsrtvf',
 	\ 'sql'    : '%ssql%ssql%scFPrstTvfp',

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -1146,7 +1146,23 @@ Available extensions:~
     - Name: 'bookmarkdir'
     - Commands: ":CtrlPBookmarkDir",
                 ":CtrlPBookmarkDirAdd [directory]".
+                ":CtrlPBookmarkDirAdd!".
+
     - Search for a bookmarked directory and change the working directory to it.
+    - Asks for a [TITLE] and the directory [directory] and adds [directory] under 
+      the title [TITLE] to the CtrlPBookmarkDir list
+    - Add the current work dir [CWD] under the title [CWD] to the CtrlPBookmarkDir 
+      list
+
+    The last command can be used to add all recently used work dirs to the 
+    CtrlPBookmarkDir list by an autocommand like
+    >
+    augroup CtrlPDirMRU
+      autocmd!
+      autocmd FileType * if &modifiable | execute 'silent CtrlPBookmarkDirAdd! %:p:h' | endif
+    augroup END
+    <
+    
     - Mappings:
       + <cr> change the local working directory for CtrlP, keep it open and
         switch to find file mode.


### PR DESCRIPTION
This adds an "init" callback for custom ignore functions. This callback will be called once as CtrlP is about to show the list of all possible filenames, and that's where you can do something expensive, like loading a custom list of patterns to filter against.

That's what I do in my "autoignore" extension [over here](https://bitbucket.org/ludovicchabant/dotfiles/src/75f61949dc1c46c85eabca7a2d3955bea14b2b15/vim/autoload/ctrlpext/autoignore.vim?at=default). In the init function I read a `.ctrlpignore` file at the root of the project, which contains the patterns to ignore.

This is a lot more efficient than figuring ways to do it only on the first file or something.

