### PR TITLE
Use empty "extra" option for ctags

### DIFF
--- a/autoload/ctrlp/buffertag.vim
+++ b/autoload/ctrlp/buffertag.vim
@@ -130,7 +130,7 @@ fu! s:exectags(cmd)
 endf
 
 fu! s:exectagsonfile(fname, ftype)
-	let [ags, ft] = ['-f - --sort=no --excmd=pattern --fields=nKs ', a:ftype]
+	let [ags, ft] = ['-f - --sort=no --excmd=pattern --fields=nKs --extra= ', a:ftype]
 	if type(s:types[ft]) == 1
 		let ags .= s:types[ft]
 		let bin = s:bin


### PR DESCRIPTION
If a user has added "--extra=+q" in their ~/.ctags to include qualified tags then ctrlp will list all tags twice, once in a qualified and once in a base form. Force an empty "extra" option to prevent this.
