### PR TITLE
Add new extensions function: update

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -574,6 +574,9 @@ fu! s:Update(str)
 	let str = s:sanstail(a:str)
 	" Stop if the string's unchanged
 	if str == oldstr && !empty(str) && !exists('s:force') | retu | en
+	" Optionally send the string to an extensions update function
+	let ext_update = s:getextvar('update')
+	if ext_update != -1 | let str = call(ext_update, [str]) | en
 	let s:martcs = &scs && str =~ '\u' ? '\C' : ''
 	let pat = s:matcher == {} ? s:SplitPattern(str) : str
 	let lines = s:nolim == 1 && empty(str) ? copy(g:ctrlp_lines)
@@ -2320,6 +2323,7 @@ fu! ctrlp#init(type, ...)
 	cal s:BuildPrompt(1)
 	if s:keyloop | cal s:KeyLoop() | en
 endf
+
 " - Autocmds {{{1
 if has('autocmd')
 	aug CtrlPAug


### PR DESCRIPTION
This came up while working on #67, which resulted in https://github.com/LFDM/ctrlp_custom_modes

Allows to manipulate the user's input string just before it is used with the matching algorithm. The function is optional and can be declared like this:

```vimscript
call add(g:ctrlp_ext_vars, {
	\ 'init': 'ctrlp#sample#init()',
	\ 'accept': 'ctrlp#sample#accept',
	\ 'lname': 'long statusline name',
	\ 'sname': 'shortname',
	\ 'type': 'line',
	\ 'enter': 'ctrlp#sample#enter()',
        \ 'update': 'ctrlp#sample#update          "  <--- the new update function
	\ 'exit': 'ctrlp#sample#exit()',
	\ 'opts': 'ctrlp#sample#opts()',
	\ 'sort': 0,
	\ 'specinput': 0,
	\ })
```

Only the name of the function needs to be given. It will be invoked with one argument: The string the user just wrote.

Example:

```
function! ctrlp#sample#update(str)
  // Do some manipulation of the input string if you want
  return str
endfunction
```
I couldn't find any other way to do this - if there is one, I am grateful for pointers.