### PR TITLE
Remove typo to uniformize dir path & Make $HOME in MRU relative

### DIFF
--- a/autoload/ctrlp/bookmarkdir.vim
+++ b/autoload/ctrlp/bookmarkdir.vim
@@ -114,7 +114,8 @@ endf
 
 fu! ctrlp#bookmarkdir#add(bang, dir, ...)
 	if a:bang == '!'
-		let cwd = fnamemodify(a:dir != '' ? a:dir : getcwd(), ':p')
+		let cwd = fnamemodify(a:dir != '' ? a:dir : getcwd(), 
+												\ g:ctrlp_mruf_tilde_homedir ? ':p:~' : ':p')
 		let name = a:0 && a:1 != '' ? a:1 : cwd
 	el
 		let str = 'Directory to bookmark: '

--- a/autoload/ctrlp/bookmarkdir.vim
+++ b/autoload/ctrlp/bookmarkdir.vim
@@ -114,7 +114,7 @@ endf
 
 fu! ctrlp#bookmarkdir#add(bang, dir, ...)
 	if a:bang == '!'
-		let cwd = fnamemodify(a:dir != '' ? a:dir : getcwd(), 'p')
+		let cwd = fnamemodify(a:dir != '' ? a:dir : getcwd(), ':p')
 		let name = a:0 && a:1 != '' ? a:1 : cwd
 	el
 		let str = 'Directory to bookmark: '

--- a/autoload/ctrlp/mrufiles.vim
+++ b/autoload/ctrlp/mrufiles.vim
@@ -15,6 +15,7 @@ fu! ctrlp#mrufiles#opts()
 		\ 'case_sensitive': ['s:cseno', 1],
 		\ 'relative': ['s:re', 0],
 		\ 'save_on_update': ['s:soup', 1],
+		\ 'tilde_homedir': ['s:thd', 0],
 		\ }]
 	for [ke, va] in items(opts)
 		let [{va[0]}, {pref.ke}] = [pref.ke, exists(pref.ke) ? {pref.ke} : va[1]]
@@ -66,10 +67,11 @@ fu! s:record(bufnr)
 endf
 
 fu! s:addtomrufs(fname)
-	let fn = fnamemodify(a:fname, ':p')
+	let fn = fnamemodify(a:fname, g:ctrlp_mruf_tilde_homedir ? ':p:~' : ':p')
 	let fn = exists('+ssl') ? tr(fn, '/', '\') : fn
+	let abs_fn = fnamemodify(fn,':p')
 	if ( !empty({s:in}) && fn !~# {s:in} ) || ( !empty({s:ex}) && fn =~# {s:ex} )
-		\ || !empty(getbufvar('^'.fn.'$', '&bt')) || !filereadable(fn) | retu
+		\ || !empty(getbufvar('^' . abs_fn . '$', '&bt')) || !filereadable(abs_fn) | retu
 	en
 	let idx = index(s:mrufs, fn, 0, !{s:cseno})
 	if idx

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -70,6 +70,7 @@ Overview:~
   |ctrlp_mruf_exclude|..........Files that shouldn't be remembered.
   |ctrlp_mruf_include|..........Files to be remembered.
   |ctrlp_mruf_relative|.........Show only MRU files in the working directory.
+  |ctrlp_mruf_tilde_homedir|....Save MRU file paths in home dir as ~/.
   |ctrlp_mruf_default_order|....Disable sorting.
   |ctrlp_mruf_case_sensitive|...MRU files are case sensitive or not.
   |ctrlp_mruf_save_on_update|...Save to disk whenever a new entry is added.
@@ -575,6 +576,14 @@ Example: >
   let g:ctrlp_mruf_include = '\.py$\|\.rb$'
 <
 
+                                                 *'g:ctrlp_mruf_tilde_homedir'*
+Set this to 1 to save every MRU file path $HOME/$filepath in the $HOME dir
+  as ~/$filepath instead of $HOME/$filepath : >
+  let g:ctrlp_mruf_tilde_homedir = 0
+<
+Note: This applies also to all dir paths stored by :CtrlPBookmarkDirAdd!
+<
+
                                                       *'g:ctrlp_mruf_relative'*
 Set this to 1 to show only MRU files in the current working directory: >
   let g:ctrlp_mruf_relative = 0
@@ -582,7 +591,6 @@ Set this to 1 to show only MRU files in the current working directory: >
 Note: you can use a custom mapping to toggle this option inside the prompt: >
   let g:ctrlp_prompt_mappings = { 'ToggleMRURelative()': ['<F2>'] }
 <
-
                                                  *'g:ctrlp_mruf_default_order'*
 Set this to 1 to disable sorting when searching in MRU mode: >
   let g:ctrlp_mruf_default_order = 0


### PR DESCRIPTION
Commit https://github.com/Konfekt/ctrlp.vim/commit/f6cb0f07eb41ea47eb83efc2e75a123abbad6d10 resolves that  `:CtrlPBookmarkDir!` adds the `cwd` twice: With and without a trailing slash.

Commit https://github.com/Konfekt/ctrlp.vim/commit/553f25050c52f730ba5cd3326b01a7a96b93dd50 adds an option `g:ctrlp_mruf_tilde_homedir` to save MRU and `CtrlPBookmarkDir!` added paths (that can be used to build a directory MRU) as path's relative to the home dir. That is, with `g:ctrlp_mruf_tilde_homedir=1` (but = 0 by default) `/home/username/file` will be saved as `~/file`.

This way,

* the MRU contains less unnecessary clutter, and
* the MRU stays valid if the full path of $HOME changes (for example on Windows, under cygwin and under other accounts)