### PR TITLE
Nomod (follow up to https://github.com/ctrlpvim/ctrlp.vim/pull/43)

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -218,6 +218,7 @@ fu! s:opts(...)
 	for each in ['byfname', 'regexp'] | if exists(each)
 		let s:{each} = {each}
 	en | endfo
+	if !exists('g:ctrlp_tilde_homedir') | let g:ctrlp_tilde_homedir = 0 | en
 	if !exists('g:ctrlp_newcache') | let g:ctrlp_newcache = 0 | en
 	let s:maxdepth = min([s:maxdepth, 100])
 	let s:glob = s:showhidden ? '.*\|*' : '*'

--- a/autoload/ctrlp/bookmarkdir.vim
+++ b/autoload/ctrlp/bookmarkdir.vim
@@ -113,15 +113,14 @@ fu! ctrlp#bookmarkdir#accept(mode, str)
 endf
 
 fu! ctrlp#bookmarkdir#add(bang, dir, ...)
+	let cwd = fnamemodify(getcwd(), g:ctrlp_mruf_tilde_homedir ? ':p:~' : ':p')
 	if a:bang == '!'
-		let cwd = fnamemodify(a:dir != '' ? a:dir : getcwd(), 
-												\ g:ctrlp_mruf_tilde_homedir ? ':p:~' : ':p')
+		let cwd = fnamemodify(a:dir != '' ? a:dir : cwd)
 		let name = a:0 && a:1 != '' ? a:1 : cwd
 	el
 		let str = 'Directory to bookmark: '
-		let cwd = a:dir != '' ? a:dir : s:getinput(str, getcwd(), 'dir')
+		let cwd = a:dir != '' ? a:dir : s:getinput(str, cwd, 'dir')
 		if cwd == '' | retu | en
-		let cwd = fnamemodify(cwd, ':p')
 		let name = a:0 && a:1 != '' ? a:1 : s:getinput('Bookmark as: ', cwd)
 		if name == '' | retu | en
 	en

--- a/autoload/ctrlp/bookmarkdir.vim
+++ b/autoload/ctrlp/bookmarkdir.vim
@@ -113,13 +113,14 @@ fu! ctrlp#bookmarkdir#accept(mode, str)
 endf
 
 fu! ctrlp#bookmarkdir#add(bang, dir, ...)
-	let cwd = fnamemodify(getcwd(), g:ctrlp_mruf_tilde_homedir ? ':p:~' : ':p')
+	let cwd = fnamemodify(getcwd(), g:ctrlp_tilde_homedir ? ':p:~' : ':p')
+	let dir = fnamemodify(a:dir, g:ctrlp_tilde_homedir ? ':p:~' : ':p')
 	if a:bang == '!'
-		let cwd = fnamemodify(a:dir != '' ? a:dir : cwd)
+		let cwd = dir != '' ? dir : cwd
 		let name = a:0 && a:1 != '' ? a:1 : cwd
 	el
 		let str = 'Directory to bookmark: '
-		let cwd = a:dir != '' ? a:dir : s:getinput(str, cwd, 'dir')
+		let cwd = dir != '' ? dir : s:getinput(str, cwd, 'dir')
 		if cwd == '' | retu | en
 		let name = a:0 && a:1 != '' ? a:1 : s:getinput('Bookmark as: ', cwd)
 		if name == '' | retu | en

--- a/autoload/ctrlp/mrufiles.vim
+++ b/autoload/ctrlp/mrufiles.vim
@@ -15,6 +15,7 @@ fu! ctrlp#mrufiles#opts()
 		\ 'case_sensitive': ['s:cseno', 1],
 		\ 'relative': ['s:re', 0],
 		\ 'save_on_update': ['s:soup', 1],
+		\ 'exclude_nomod': ['s:exclnomod', 0],
 		\ }]
 	for [ke, va] in items(opts)
 		let [{va[0]}, {pref.ke}] = [pref.ke, exists(pref.ke) ? {pref.ke} : va[1]]
@@ -55,6 +56,8 @@ fu! s:reformat(mrufs, ...)
 endf
 
 fu! s:record(bufnr)
+	if s:exclnomod && &l:modifiable | retu | en
+  if s:exclnomod && !&l:modifiable | retu | en
 	if s:locked | retu | en
 	let bufnr = a:bufnr + 0
 	let bufname = bufname(bufnr)
@@ -144,7 +147,7 @@ fu! ctrlp#mrufiles#init()
 	let s:locked = 0
 	aug CtrlPMRUF
 		au!
-		au BufAdd,BufEnter,BufLeave,BufWritePost * cal s:record(expand('<abuf>', 1))
+		au BufWinEnter,BufWinLeave,BufWritePost * cal s:record(expand('<abuf>', 1))
 		au QuickFixCmdPre  *vimgrep* let s:locked = 1
 		au QuickFixCmdPost *vimgrep* let s:locked = 0
 		au VimLeavePre * cal s:savetofile(s:mergelists())

--- a/autoload/ctrlp/mrufiles.vim
+++ b/autoload/ctrlp/mrufiles.vim
@@ -15,7 +15,6 @@ fu! ctrlp#mrufiles#opts()
 		\ 'case_sensitive': ['s:cseno', 1],
 		\ 'relative': ['s:re', 0],
 		\ 'save_on_update': ['s:soup', 1],
-		\ 'tilde_homedir': ['s:thd', 0],
 		\ }]
 	for [ke, va] in items(opts)
 		let [{va[0]}, {pref.ke}] = [pref.ke, exists(pref.ke) ? {pref.ke} : va[1]]
@@ -67,7 +66,7 @@ fu! s:record(bufnr)
 endf
 
 fu! s:addtomrufs(fname)
-	let fn = fnamemodify(a:fname, g:ctrlp_mruf_tilde_homedir ? ':p:~' : ':p')
+	let fn = fnamemodify(a:fname, g:ctrlp_tilde_homedir ? ':p:~' : ':p')
 	let fn = exists('+ssl') ? tr(fn, '/', '\') : fn
 	let abs_fn = fnamemodify(fn,':p')
 	if ( !empty({s:in}) && fn !~# {s:in} ) || ( !empty({s:ex}) && fn =~# {s:ex} )

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -70,7 +70,7 @@ Overview:~
   |ctrlp_mruf_exclude|..........Files that shouldn't be remembered.
   |ctrlp_mruf_include|..........Files to be remembered.
   |ctrlp_mruf_relative|.........Show only MRU files in the working directory.
-  |ctrlp_mruf_tilde_homedir|....Save MRU file paths in home dir as ~/.
+  |ctrlp_tilde_homedir|....Save MRU file paths in home dir as ~/.
   |ctrlp_mruf_default_order|....Disable sorting.
   |ctrlp_mruf_case_sensitive|...MRU files are case sensitive or not.
   |ctrlp_mruf_save_on_update|...Save to disk whenever a new entry is added.
@@ -576,10 +576,10 @@ Example: >
   let g:ctrlp_mruf_include = '\.py$\|\.rb$'
 <
 
-                                                 *'g:ctrlp_mruf_tilde_homedir'*
+                                                 *'g:ctrlp_tilde_homedir'*
 Set this to 1 to save every MRU file path $HOME/$filepath in the $HOME dir
   as ~/$filepath instead of $HOME/$filepath : >
-  let g:ctrlp_mruf_tilde_homedir = 0
+  let g:ctrlp_tilde_homedir = 0
 <
 Note: This applies also to all dir paths stored by :CtrlPBookmarkDirAdd!
 <
@@ -1164,7 +1164,7 @@ Available extensions:~
       work dir ( [CWD] ) under the title given by either [TITLE], if supplied,
       or otherwise [CWD] to the CtrlPBookmarkDir list.
 
-    The last command can be used to add all recently used work dirs to the 
+    The last command can be used to add all recently used work dirs to the
     CtrlPBookmarkDir list by an autocommand like
     >
     augroup CtrlPDirMRU
@@ -1172,7 +1172,7 @@ Available extensions:~
       autocmd FileType * if &modifiable | execute 'silent CtrlPBookmarkDirAdd! %:p:h' | endif
     augroup END
     <
-    
+
     - Mappings:
       + <cr> change the local working directory for CtrlP, keep it open and
         switch to find file mode.

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -74,6 +74,7 @@ Overview:~
   |ctrlp_mruf_default_order|....Disable sorting.
   |ctrlp_mruf_case_sensitive|...MRU files are case sensitive or not.
   |ctrlp_mruf_save_on_update|...Save to disk whenever a new entry is added.
+  |ctrlp_mruf_exclude_nomod|....Exclude nonmodifiable buffers from the MRU list.
 
   BufferTag mode: (to enable, see |ctrlp-extensions|)
   |g:ctrlp_buftag_ctags_bin|....The location of the ctags-compatible binary.
@@ -608,6 +609,11 @@ entry is added, saving will then only occur when exiting Vim: >
   let g:ctrlp_mruf_save_on_update = 1
 <
 
+                                                *'g:ctrlp_mruf_exclude_nomod'*
+Set this to 1 to disable adding nonmodifiable buffers, for example help files,
+to the MRU list: >
+  let g:ctrlp_mruf_exclude_nomod = 0
+<
 ----------------------------------------
 Advanced options:~
 

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -1153,14 +1153,16 @@ Available extensions:~
   * BookmarkDir mode:~
     - Name: 'bookmarkdir'
     - Commands: ":CtrlPBookmarkDir",
-                ":CtrlPBookmarkDirAdd [directory]".
-                ":CtrlPBookmarkDirAdd!".
+                ":CtrlPBookmarkDirAdd  [directory] [TITLE]".
+                ":CtrlPBookmarkDirAdd! [directory] [TITLE]".
 
     - Search for a bookmarked directory and change the working directory to it.
-    - Asks for a [TITLE] and the directory [directory] and adds [directory] under 
-      the title [TITLE] to the CtrlPBookmarkDir list
-    - Add the current work dir [CWD] under the title [CWD] to the CtrlPBookmarkDir 
-      list
+    - Add either the dir [directory], if supplied, or otherwise ask for it,
+      under the title given by either [TITLE], if supplied, or otherwise ask for
+      it, to the CtrlPBookmarkDir list.
+    - Add either the dir [directory], if supplied, or otherwise the current
+      work dir ( [CWD] ) under the title given by either [TITLE], if supplied,
+      or otherwise [CWD] to the CtrlPBookmarkDir list.
 
     The last command can be used to add all recently used work dirs to the 
     CtrlPBookmarkDir list by an autocommand like


### PR DESCRIPTION


For example, when searching for .txt the MRU is crammed by recent accesses to the VIM doc by K. With this addtitional option g:ctrlp_mruf_exclude_nomod, these files, as well as all other nonmodifiable buffers are no longer added to the MRU list.

I also cleaned up the autocmd events for the MRU list. Please check that it suits you. Regardless, the BufWinEnter autocmd is crucial to check at the right time if the buffer is nonmodifiable.
