### PR TITLE
Fix auto selection of tag from tselect menu for tags in the same file.

### DIFF
--- a/autoload/ctrlp/tag.vim
+++ b/autoload/ctrlp/tag.vim
@@ -21,7 +21,7 @@ cal add(g:ctrlp_ext_vars, {
 
 let s:id = g:ctrlp_builtins + len(g:ctrlp_ext_vars)
 " Utilities {{{1
-fu! s:findcount(str)
+fu! s:findcount(str, tgaddr)
 	let [tg, ofname] = split(a:str, '\t\+\ze[^\t]\+$')
 	let tgs = taglist('^'.tg.'$')
 	if len(tgs) < 2
@@ -48,7 +48,13 @@ fu! s:findcount(str)
 	for tgi in ntgs
 		let cnt += 1
 		if tgi["filename"] == ofname
-			let [fnd, pos] = [0, cnt]
+			if a:tgaddr != ""
+				if a:tgaddr == tgi["cmd"]
+					let [fnd, pos] = [0, cnt]
+				en
+			else
+				let [fnd, pos] = [0, cnt]
+			en
 		en
 	endfo
 	retu [1, fnd, pos, len(ctgs)]
@@ -92,8 +98,9 @@ endf
 
 fu! ctrlp#tag#accept(mode, str)
 	cal ctrlp#exit()
+	let tgaddr = matchstr(a:str, '^[^\t]\+\t\+[^\t]\+\t\zs[^\t]\{-1,}\ze\%(;"\)\?\t')
 	let str = matchstr(a:str, '^[^\t]\+\t\+[^\t]\+\ze\t')
-	let [tg, fdcnt] = [split(str, '^[^\t]\+\zs\t')[0], s:findcount(str)]
+	let [tg, fdcnt] = [split(str, '^[^\t]\+\zs\t')[0], s:findcount(str, tgaddr)]
 	let cmds = {
 		\ 't': ['tab sp', 'tab stj'],
 		\ 'h': ['sp', 'stj'],


### PR DESCRIPTION
Starting with commit 83397bd0, when possible Ctrlp tries to autoselect
a tag from from the `tselect` menu.

This has a significant flaw though, as it does not select the correct tag
when there are multiple tags with the same name in the same file, instead
preferring to always use the last tag from that file.

By matching not just on filename of the selected tag, but also on the
tagaddress (generally a regex or linenumber), we ensure that the correct
tag is always selected from the tselect prompt.