### PR TITLE
add option to exclude temp files from MRU

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -87,7 +87,7 @@ let [s:pref, s:bpref, s:opts, s:new_opts, s:lc_opts] =
 	\ 'tabpage_position':      ['s:tabpage', 'ac'],
 	\ 'use_caching':           ['s:caching', 1],
 	\ 'user_command':          ['s:usrcmd', ''],
-  \ 'validate':              ['s:validate', ''],
+	\ 'validate':              ['s:validate', ''],
 	\ 'working_path_mode':     ['s:pathmode', 'ra'],
 	\ 'line_prefix':					 ['s:lineprefix', '> '],
 	\ }, {

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -88,6 +88,7 @@ let [s:pref, s:bpref, s:opts, s:new_opts, s:lc_opts] =
 	\ 'use_caching':           ['s:caching', 1],
 	\ 'user_command':          ['s:usrcmd', ''],
 	\ 'working_path_mode':     ['s:pathmode', 'ra'],
+	\ 'line_prefix':					 ['s:lineprefix', '> '],
 	\ }, {
 	\ 'open_multiple_files':   's:opmul',
 	\ 'regexp':                's:regexp',
@@ -1458,7 +1459,7 @@ fu! s:formatline(str)
 		let str .= idc != '' ? ' '.idc : ''
 	en
 	let cond = s:ispath && ( s:winw - 4 ) < s:strwidth(str)
-	retu '> '.( cond ? s:pathshorten(str) : str )
+	retu s:lineprefix.( cond ? s:pathshorten(str) : str )
 endf
 
 fu! s:pathshorten(str)

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -590,6 +590,9 @@ fu! s:Update(str)
 	let str = s:sanstail(a:str)
 	" Stop if the string's unchanged
 	if str == oldstr && !empty(str) && !exists('s:force') | retu | en
+	" Optionally send the string to an extensions update function
+	let ext_update = s:getextvar('update')
+	if ext_update != -1 | let str = call(ext_update, [str]) | en
 	let s:martcs = &scs && str =~ '\u' ? '\C' : ''
 	let pat = s:matcher == {} ? s:SplitPattern(str) : str
 	let lines = s:nolim == 1 && empty(str) ? copy(g:ctrlp_lines)
@@ -2336,6 +2339,7 @@ fu! ctrlp#init(type, ...)
 	cal s:BuildPrompt(1)
 	if s:keyloop | cal s:KeyLoop() | en
 endf
+
 " - Autocmds {{{1
 if has('autocmd')
 	aug CtrlPAug

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -87,6 +87,7 @@ let [s:pref, s:bpref, s:opts, s:new_opts, s:lc_opts] =
 	\ 'tabpage_position':      ['s:tabpage', 'ac'],
 	\ 'use_caching':           ['s:caching', 1],
 	\ 'user_command':          ['s:usrcmd', ''],
+  \ 'validate':              ['s:validate', ''],
 	\ 'working_path_mode':     ['s:pathmode', 'ra'],
 	\ 'line_prefix':					 ['s:lineprefix', '> '],
 	\ }, {
@@ -590,9 +591,8 @@ fu! s:Update(str)
 	let str = s:sanstail(a:str)
 	" Stop if the string's unchanged
 	if str == oldstr && !empty(str) && !exists('s:force') | retu | en
-	" Optionally send the string to an extensions update function
-	let ext_update = s:getextvar('update')
-	if ext_update != -1 | let str = call(ext_update, [str]) | en
+	" Optionally send the string to a custom validate function
+	if s:validate != '' | let str = call(s:validate, [str]) | en
 	let s:martcs = &scs && str =~ '\u' ? '\C' : ''
 	let pat = s:matcher == {} ? s:SplitPattern(str) : str
 	let lines = s:nolim == 1 && empty(str) ? copy(g:ctrlp_lines)
@@ -2339,7 +2339,6 @@ fu! ctrlp#init(type, ...)
 	cal s:BuildPrompt(1)
 	if s:keyloop | cal s:KeyLoop() | en
 endf
-
 " - Autocmds {{{1
 if has('autocmd')
 	aug CtrlPAug

--- a/autoload/ctrlp/bookmarkdir.vim
+++ b/autoload/ctrlp/bookmarkdir.vim
@@ -113,8 +113,9 @@ fu! ctrlp#bookmarkdir#accept(mode, str)
 endf
 
 fu! ctrlp#bookmarkdir#add(bang, dir, ...)
-	let cwd = fnamemodify(getcwd(), g:ctrlp_tilde_homedir ? ':p:~' : ':p')
-	let dir = fnamemodify(a:dir, g:ctrlp_tilde_homedir ? ':p:~' : ':p')
+	let ctrlp_tilde_homedir = get(g:, 'ctrlp_tilde_homedir', 0)
+	let cwd = fnamemodify(getcwd(), ctrlp_tilde_homedir ? ':p:~' : ':p')
+	let dir = fnamemodify(a:dir, ctrlp_tilde_homedir ? ':p:~' : ':p')
 	if a:bang == '!'
 		let cwd = dir != '' ? dir : cwd
 		let name = a:0 && a:1 != '' ? a:1 : cwd

--- a/autoload/ctrlp/mrufiles.vim
+++ b/autoload/ctrlp/mrufiles.vim
@@ -69,7 +69,7 @@ fu! s:record(bufnr)
 endf
 
 fu! s:addtomrufs(fname)
-	let fn = fnamemodify(a:fname, g:ctrlp_tilde_homedir ? ':p:~' : ':p')
+	let fn = fnamemodify(a:fname, get(g:, 'ctrlp_tilde_homedir', 0) ? ':p:~' : ':p')
 	let fn = exists('+ssl') ? tr(fn, '/', '\') : fn
 	let abs_fn = fnamemodify(fn,':p')
 	if ( !empty({s:in}) && fn !~# {s:in} ) || ( !empty({s:ex}) && fn =~# {s:ex} )

--- a/autoload/ctrlp/mrufiles.vim
+++ b/autoload/ctrlp/mrufiles.vim
@@ -56,16 +56,22 @@ fu! s:reformat(mrufs, ...)
 endf
 
 fu! s:record(bufnr)
-	if s:exclnomod && &l:modifiable | retu | en
-  if s:exclnomod && !&l:modifiable | retu | en
 	if s:locked | retu | en
+
 	let bufnr = a:bufnr + 0
 	let bufname = bufname(bufnr)
-	if bufnr > 0 && !empty(bufname)
-		cal filter(s:mrbs, 'v:val != bufnr')
-		cal insert(s:mrbs, bufnr)
-		cal s:addtomrufs(bufname)
+
+	if bufnr == 0 || !filereadable(bufname) | retu | en
+  if s:exclnomod && !getbufvar(bufnr,'&modifiable') | retu | en
+  if s:excltemp
+		for tmpdir in [$TMPDIR, $TEMP, $TMP, '/tmp'] "  = set backupskip&?
+			if !empty(tmpdir) && bufname =~# '\v^' . tmpdir . '[\/]' | retu | en
+		endfo
 	en
+
+	cal filter(s:mrbs, 'v:val != bufnr')
+	cal insert(s:mrbs, bufnr)
+	cal s:addtomrufs(bufname)
 endf
 
 fu! s:addtomrufs(fname)


### PR DESCRIPTION
After comitting from Fugitive, there is a temp file added to the MRU. This option prevents this.

Also cleaned up the check if the buffer name should go to the MRU as a whole. 