### PR TITLE
cleanup mru record function

### DIFF
--- a/autoload/ctrlp/mrufiles.vim
+++ b/autoload/ctrlp/mrufiles.vim
@@ -16,7 +16,6 @@ fu! ctrlp#mrufiles#opts()
 		\ 'case_sensitive': ['s:cseno', 1],
 		\ 'relative': ['s:re', 0],
 		\ 'save_on_update': ['s:soup', 1],
-		\ 'exclude_nomod': ['s:exclnomod', 0],
 		\ 'map_string': ['g:ctrlp_mruf_map_string', s:mruf_map_string],
 		\ }]
 	for [ke, va] in items(opts)
@@ -58,8 +57,6 @@ fu! s:reformat(mrufs, ...)
 endf
 
 fu! s:record(bufnr)
-	if s:exclnomod && &l:modifiable | retu | en
-  if s:exclnomod && !&l:modifiable | retu | en
 	if s:locked | retu | en
 	let bufnr = a:bufnr + 0
 	let bufname = bufname(bufnr)
@@ -75,7 +72,8 @@ fu! s:addtomrufs(fname)
 	let fn = exists('+ssl') ? tr(fn, '/', '\') : fn
 	let abs_fn = fnamemodify(fn,':p')
 	if ( !empty({s:in}) && fn !~# {s:in} ) || ( !empty({s:ex}) && fn =~# {s:ex} )
-		\ || !empty(getbufvar('^' . abs_fn . '$', '&bt')) || !filereadable(abs_fn) | retu
+		\ || !empty(getbufvar('^' . abs_fn . '$', '&bt'))
+		retu
 	en
 	let idx = index(s:mrufs, fn, 0, !{s:cseno})
 	if idx

--- a/doc/ctrlp.cnx
+++ b/doc/ctrlp.cnx
@@ -82,7 +82,6 @@ OPTIONS                                                         *ctrlp-options*
   |ctrlp_mruf_default_order|....禁用排序。
   |ctrlp_mruf_case_sensitive|...最近最多使用文件是否大小写敏感。
   |ctrlp_mruf_save_on_update|...只要有一个新的条目添加，就保存到磁盘。
-  |ctrlp_mruf_exclude_nomod|....从 MRU 中排除不可编辑的缓冲区。
 
   缓冲区标签模式: (开启此模式，参考 |ctrlp-extensions| )
   |g:ctrlp_buftag_ctags_bin|....兼容的ctags二进制程序的位置。
@@ -583,11 +582,6 @@ MRU mode options:~
 设置该选项为0将不会每当有一个新条目增加就把最近最多使用列表保存到磁盘文件，而
 是在退出Vim时才保存: >
   let g:ctrlp_mruf_save_on_update = 1
-<
-
-                                                *'g:ctrlp_mruf_exclude_nomod'*
-将这个选项设置为1来禁止添加不可编辑的缓冲区，例如帮助文件，到 MRU 列表: >
-  let g:ctrlp_mruf_exclude_nomod = 0
 <
 ----------------------------------------
 高级选项:~

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -77,7 +77,6 @@ Overview:~
   |ctrlp_mruf_default_order|....Disable sorting.
   |ctrlp_mruf_case_sensitive|...MRU files are case sensitive or not.
   |ctrlp_mruf_save_on_update|...Save to disk whenever a new entry is added.
-  |ctrlp_mruf_exclude_nomod|....Exclude nonmodifiable buffers from the MRU list.
 
   BufferTag mode: (to enable, see |ctrlp-extensions|)
   |g:ctrlp_buftag_ctags_bin|....The location of the ctags-compatible binary.
@@ -639,12 +638,6 @@ MRU entries: >
 Set this to 0 to disable saving of the MRU list to hard drive whenever a new
 entry is added, saving will then only occur when exiting Vim: >
   let g:ctrlp_mruf_save_on_update = 1
-<
-
-                                                *'g:ctrlp_mruf_exclude_nomod'*
-Set this to 1 to disable adding nonmodifiable buffers, for example help files,
-to the MRU list: >
-  let g:ctrlp_mruf_exclude_nomod = 0
 <
 ----------------------------------------
 Advanced options:~


### PR DESCRIPTION
For example after comitting from vim-fugitive, there is a temp file added to the MRU. This option prevents this.

Also cleaned up the check if the buffer name should go to the MRU as a whole.
