### PR TITLE
`file:line|column` format for jump to line and column

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1028,7 +1028,7 @@ fu! ctrlp#acceptfile(...)
 	en
 	cal s:PrtExit()
 	let tail = s:tail()
-	let j2l = atl != '' ? atl : matchstr(tail, '^ +\zs\d\+$')
+	let j2l = atl != '' ? atl : matchstr(tail, '^ +\zs\d\+\(|\d\+\)$')
 	if ( s:jmptobuf =~ md || ( !empty(s:jmptobuf) && s:jmptobuf !~# '\v^0$' && md =~ '[et]' ) ) && bufnr > 0
 		\ && !( md == 'e' && bufnr == bufnr('%') )
 		let [jmpb, bufwinnr] = [1, bufwinnr(bufnr)]
@@ -2047,7 +2047,16 @@ fu! s:strwidth(str)
 endf
 
 fu! ctrlp#j2l(nr)
-	exe 'norm!' a:nr.'G'
+	let nums = matchlist(a:nr, '\(\d\+\)|\(\d\+\)')
+	let line = nums[1]
+	let column = nums[2]
+
+	let cmd = line . 'G'
+
+	if column != ''
+		let cmd .= column . '|'
+	end
+	exe 'norm!' cmd
 	sil! norm! zvzz
 endf
 
@@ -2134,8 +2143,13 @@ fu! s:openfile(cmd, fid, tail, chkmod, ...)
 		let cmd = cmd == 'b' ? 'sb' : 'sp'
 	en
 	let cmd = cmd =~ '^tab' ? ctrlp#tabcount().cmd : cmd
-	let j2l = a:0 && a:1[0] ? a:1[1] : 0
-	exe cmd.( a:0 && a:1[0] ? '' : a:tail ) s:fnesc(a:fid, 'f')
+
+	" a:0 -> ic??
+	" a:1[0] -> useb
+	" a:1[1] -> address
+
+	let j2l = a:0 && a:1[1] ? a:1[1] : 0
+	exe cmd.( a:0 && a:1[1] ? '' : a:tail ) s:fnesc(a:fid, 'f')
 	if j2l
 		cal ctrlp#j2l(j2l)
 	en


### PR DESCRIPTION
A lot of the compilers nowadays provide the line and column number of an error or warning. For the longest time I've wanted to be able to switch to a file in ctrlp and specify the line and column number in one go, so I could do `problemfile:25|10` to open problemfile at line 25 column 10. The same effect can already be achieved of course by just doing `problemfile:25` and then using the `10|` motion, or by leveraging the existing 'tail' command functionality in ctrlp and doing `problemfile:+norm!\ 25G10|` but I think most would agree that that is too tedious. It's really nice and fast to be able to specify this in one go.

I managed to implement it, but I'm not familiar with the ctrlp codebase so I don't know if there's a better way of accomplishing this.

I basically add a pattern to match on the optional column component and modify `ctrlp#j2l` accordingly.

The tricky part that I'm unsure of is that `s:openfile` insists on ignoring `j2l` (which is exposed there as `a:1[1]`) because `useb` is false (`a:1[0]`), and so it tries to use the regular tail cmd. I need a way to have it use `ctrlp#j2l` if `j2l` is set. Currently what I do is I force it set, ignoring `useb`. I figure that if `j2l` is set then there really isn't a tail anyways, since `j2l` is in part set by attempting to match on the _entire_ `tail` to see if it consists of the line number:

``` vim
let j2l = atl != '' ? atl : matchstr(tail, '^ +\zs\d\+$')
```

I'm not sure what `atl` is exactly and if that may cause problems. My assumption is that it shouldn't cause problems, because it seems to accept the `atl` verbatim as the `j2l` if the `atl` is indeed set, so it should already be correctly-formed, I imagine.

Still, I'm wondering if there's a better way to accomplish this. Hopefully some of you find this feature as convenient as I do.