### PR TITLE
Allow easier customizing of list format

### DIFF
--- a/autoload/ctrlp/mrufiles.vim
+++ b/autoload/ctrlp/mrufiles.vim
@@ -54,7 +54,7 @@ fu! s:reformat(mrufs, ...)
 		let cwd = tr(cwd, '\', '/')
 		cal map(a:mrufs, 'tr(v:val, "\\", "/")')
 	en
-  retu map(a:mrufs, g:ctrlp_mruf_map_string)
+	retu map(a:mrufs, g:ctrlp_mruf_map_string)
 endf
 
 fu! s:record(bufnr)

--- a/autoload/ctrlp/mrufiles.vim
+++ b/autoload/ctrlp/mrufiles.vim
@@ -6,6 +6,7 @@
 
 " Static variables {{{1
 let [s:mrbs, s:mrufs] = [[], []]
+let s:mruf_map_string = '!stridx(v:val, cwd) ? strpart(v:val, idx) : v:val'
 
 fu! ctrlp#mrufiles#opts()
 	let [pref, opts] = ['g:ctrlp_mruf_', {
@@ -16,6 +17,7 @@ fu! ctrlp#mrufiles#opts()
 		\ 'relative': ['s:re', 0],
 		\ 'save_on_update': ['s:soup', 1],
 		\ 'exclude_nomod': ['s:exclnomod', 0],
+		\ 'map_string': ['g:ctrlp_mruf_map_string', s:mruf_map_string],
 		\ }]
 	for [ke, va] in items(opts)
 		let [{va[0]}, {pref.ke}] = [pref.ke, exists(pref.ke) ? {pref.ke} : va[1]]
@@ -52,7 +54,7 @@ fu! s:reformat(mrufs, ...)
 		let cwd = tr(cwd, '\', '/')
 		cal map(a:mrufs, 'tr(v:val, "\\", "/")')
 	en
-	retu map(a:mrufs, '!stridx(v:val, cwd) ? strpart(v:val, idx) : v:val')
+  retu map(a:mrufs, g:ctrlp_mruf_map_string)
 endf
 
 fu! s:record(bufnr)


### PR DESCRIPTION
I have already completely this in a somewhat hacky way, but this would allow for a cleaner way to customize the list items format.

Reference to my use case: ryanoasis/vim-devicons/issues/56

```vim
" scope: local
" Either initialize for: kien/ctrlp.vim OR up to date fork: ctrlpvim/ctrlp.vim
" mostly a hack/overwrite to add icons to the official inactive ctrlP repo
" only overwriting the necessary functions to make it work
" unless we detect the newer active ctrlp fork
function! s:initializeCtrlP()
  if exists("g:loaded_ctrlp") && g:webdevicons_enable_ctrlp
    let g:ctrlp_open_func = {
      \ 'files': 'webdevicons#ctrlPOpenFunc',
      \ 'buffers': 'webdevicons#ctrlPOpenFunc',
      \ 'mru files': 'webdevicons#ctrlPOpenFunc'
      \ }

    if exists("g:ctrlp_mruf_map_string")
      " logic for ctrlpvim/ctrlp.vim:
      let g:ctrlp_mruf_map_string = '!stridx(v:val, cwd) ? WebDevIconsGetFileTypeSymbol(strpart(v:val, strridx(v:val, "/"))) . " " . strpart(v:val, idx) : g:WebDevIconsUnicodeDecorateFileNodesDefaultSymbol . " " . v:val'
    else
      " logic for kien/ctrlp.vim (somewhat ugly hack that overwrites functions to accomplish customization):
      call s:initializeCtrlPOverwrite()
    endif
  endif
endfunction

" scope: public
function! webdevicons#ctrlPOpenFunc(action, line)
  " Use CtrlP's default file opening function
  let devIconPrefixLength = 6
  let line = strpart(a:line, devIconPrefixLength)
  call call('ctrlp#acceptfile', [a:action, line])
endfunction
```