### PR TITLE
add key hint ont the status line, and the base line.

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -615,7 +615,7 @@ fu! s:ForceUpdate()
 endf
 
 fu! s:BuildPrompt(upd)
-	let base = ( s:regexp ? 'r' : '>' ).( s:byfname() ? 'd' : '>' ).'> '
+	let base = ( s:regexp ? '+r ' : '-r ' ).( s:byfname() ? '+d ' : '-d ' ).'> '
 	let str = escape(s:getinput(), '\')
 	let lazy = str == '' || exists('s:force') || !has('autocmd') ? 0 : s:lazy
 	if a:upd && !lazy && ( s:matches || s:regexp || exists('s:did_exp')
@@ -1405,8 +1405,8 @@ fu! ctrlp#statusline()
 	en
 	let tps = s:statypes
 	let max = len(tps) - 1
-	let nxt = tps[s:walker(max, s:itemtype,  1)][1]
-	let prv = tps[s:walker(max, s:itemtype, -1)][1]
+	let nxt = tps[s:walker(max, s:itemtype,  1)][1].'('. substitute(s:prtmaps['ToggleType(1)'][0],'[\<\>]','','g').')'
+	let prv = tps[s:walker(max, s:itemtype, -1)][1].'('. substitute(s:prtmaps['ToggleType(-1)'][0],'[\<\>]','','g').')'
 	let s:ctype = tps[s:itemtype][0]
 	let focus   = s:focus ? 'prt'  : 'win'
 	let byfname = s:ispath ? s:byfname ? 'file' : 'path' : 'line'


### PR DESCRIPTION
I found it hard to remember ctrlp's other mapped key. Then a add key hint on the status line text and base line text, which may remind users to use the `<c-f>`, `<c-b>`, `<c-d>` and `<c-r>` key