### PR TITLE
Add option `ctrlp_match_current_file` to include the current file in match results

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -92,6 +92,7 @@ let [s:pref, s:bpref, s:opts, s:new_opts, s:lc_opts] =
 	\ 'line_prefix':           ['s:lineprefix', '> '],
 	\ 'open_single_match':     ['s:opensingle', []],
 	\ 'brief_prompt':          ['s:brfprt', 0],
+	\ 'match_current_file':    ['s:matchcrfile', 0],
 	\ }, {
 	\ 'open_multiple_files':   's:opmul',
 	\ 'regexp':                's:regexp',
@@ -494,9 +495,12 @@ fu! s:MatchIt(items, pat, limit, exc)
 		\ : s:martcs.a:pat
 	for item in a:items
 		let id += 1
-		try | if !( s:ispath && item == a:exc ) && call(s:mfunc, [item, pat]) >= 0
-			cal add(lines, item)
-		en | cat | brea | endt
+		try
+			if (s:matchcrfile || !( s:ispath && item == a:exc )) && 
+						\call(s:mfunc, [item, pat]) >= 0
+				cal add(lines, item)
+			en
+		cat | brea | endt
 		if a:limit > 0 && len(lines) >= a:limit | brea | en
 	endfo
 	let s:mdata = [s:dyncwd, s:itemtype, s:regexp, s:sublist(a:items, id, -1)]

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -67,6 +67,7 @@ Overview:~
   |ctrlp_line_prefix|...........Prefix for each line in ctrlp window.
   |ctrlp_open_single_match|.....Automatically accept when only one candidate.
   |ctrlp_brief_prompt|..........Exit CtrlP on empty prompt by <bs>.
+  |ctrlp_match_current_file|....Include current file in match entries.
 
   MRU mode:
   |ctrlp_mruf_max|..............Max MRU entries to remember.
@@ -447,6 +448,16 @@ as the default input: >
   let g:ctrlp_default_input = 'anystring'
 <
 This option works well together with |g:ctrlp_open_single_match|
+
+
+                                                 *'g:ctrlp_match_current_file'*
+Includes the current file in the match entries:
+  let g:ctrlp_match_current_file = 1
+
+By default, the current file is excluded from the list.
+
+Note: does not apply when |g:ctrlp_match_func| is used. 
+
 
                                                              *'g:ctrlp_abbrev'*
 Define input abbreviations that can be expanded (either internally or visibly)


### PR DESCRIPTION
This adresses https://github.com/ctrlpvim/ctrlp.vim/issues/95.