### PR TITLE
Improve perfomance using external command in neovim

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -417,11 +417,11 @@ fu! s:UserCmd(lscmd)
 		let lscmd = substitute(lscmd, '\v(^|\&\&\s*)\zscd (/d)@!', 'cd /d ', '')
 	en
 	let path = exists('*shellescape') ? shellescape(path) : path
-  if has('patch-7.4-597')
-    let g:ctrlp_allfiles = systemlist(printf(lscmd, path))
-  else
-    let g:ctrlp_allfiles = split(system(printf(lscmd, path)), "\n")
-  end
+	if has('patch-7.4-597')
+		let g:ctrlp_allfiles = systemlist(printf(lscmd, path))
+	else
+		let g:ctrlp_allfiles = split(system(printf(lscmd, path)), "\n")
+	end
 	if exists('+ssl') && exists('ssl')
 		let &ssl = ssl
 		cal map(g:ctrlp_allfiles, 'tr(v:val, "\\", "/")')

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -417,7 +417,11 @@ fu! s:UserCmd(lscmd)
 		let lscmd = substitute(lscmd, '\v(^|\&\&\s*)\zscd (/d)@!', 'cd /d ', '')
 	en
 	let path = exists('*shellescape') ? shellescape(path) : path
-	let g:ctrlp_allfiles = split(system(printf(lscmd, path)), "\n")
+  if has('patch-7.4-597')
+    let g:ctrlp_allfiles = systemlist(printf(lscmd, path))
+  else
+    let g:ctrlp_allfiles = split(system(printf(lscmd, path)), "\n")
+  end
 	if exists('+ssl') && exists('ssl')
 		let &ssl = ssl
 		cal map(g:ctrlp_allfiles, 'tr(v:val, "\\", "/")')


### PR DESCRIPTION
Trying neovim, one thing I noticed was that CtrlPMixed was a lot slower. After investigation this seemed to be caused by the fact I use an external command for the file list. Using `split(system())` seems to be quite slow on neovim, while `systemlist` does work well. However, older versions of vim have an issue using `systemlist`, which is fixed in 7.4.597, hence the check.