### PR TITLE
fixed problem with ctrlp_allfiles on windows caused by PR #162

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -418,7 +418,7 @@ fu! s:UserCmd(lscmd)
 		let lscmd = substitute(lscmd, '\v(^|\&\&\s*)\zscd (/d)@!', 'cd /d ', '')
 	en
 	let path = exists('*shellescape') ? shellescape(path) : path
-	if has('patch-7.4-597')
+	if has('patch-7.4-597') && !(has('win32') || has('win64'))
 		let g:ctrlp_allfiles = systemlist(printf(lscmd, path))
 	else
 		let g:ctrlp_allfiles = split(system(printf(lscmd, path)), "\n")

--- a/autoload/ctrlp/buffertag.vim
+++ b/autoload/ctrlp/buffertag.vim
@@ -67,6 +67,7 @@ let s:types = {
 	\ 'matlab' : '%smatlab%smatlab%sf',
 	\ 'ocaml'  : '%socaml%socaml%scmMvtfCre',
 	\ 'pascal' : '%spascal%spascal%sfp',
+	\ 'delphi' : '%spascal%spascal%sfp',
 	\ 'perl'   : '%sperl%sperl%sclps',
 	\ 'php'    : '%sphp%sphp%scdvf',
 	\ 'python' : '%spython%spython%scmf',

--- a/autoload/ctrlp/buffertag.vim
+++ b/autoload/ctrlp/buffertag.vim
@@ -72,6 +72,7 @@ let s:types = {
 	\ 'python' : '%spython%spython%scmf',
 	\ 'rexx'   : '%srexx%srexx%ss',
 	\ 'ruby'   : '%sruby%sruby%scfFm',
+	\ 'rust'   : '%srust%srust%sfTgsmctid',
 	\ 'scheme' : '%sscheme%sscheme%ssf',
 	\ 'sh'     : '%ssh%ssh%sf',
 	\ 'csh'    : '%ssh%ssh%sf',


### PR DESCRIPTION
PR #162 causes Windows line endings to be included in the file list which prevents the user from opening files on Windows.  This just updates it to only use the new code if not on a Windows system.