### PR TITLE
Fix jsctags not working on Windows

### DIFF
--- a/autoload/ctrlp/buffertag.vim
+++ b/autoload/ctrlp/buffertag.vim
@@ -157,11 +157,11 @@ fu! s:esctagscmd(bin, args, ...)
 		let [ssl, &ssl] = [&ssl, 0]
 	en
 	let fname = a:0 ? shellescape(a:1) : ''
-  if  (has('win32') || has('win64'))
-    let cmd = a:bin.' '.a:args.' '.fname
-  else
-    let cmd = shellescape(a:bin).' '.a:args.' '.fname
-  endif
+	if  (has('win32') || has('win64'))
+		let cmd = a:bin.' '.a:args.' '.fname
+	else
+		let cmd = shellescape(a:bin).' '.a:args.' '.fname
+	endif
 	if &sh =~ 'cmd\.exe'
 		let cmd = substitute(cmd, '[&()@^<>|]', '^\0', 'g')
 	en

--- a/autoload/ctrlp/buffertag.vim
+++ b/autoload/ctrlp/buffertag.vim
@@ -157,7 +157,11 @@ fu! s:esctagscmd(bin, args, ...)
 		let [ssl, &ssl] = [&ssl, 0]
 	en
 	let fname = a:0 ? shellescape(a:1) : ''
-	let cmd = shellescape(a:bin).' '.a:args.' '.fname
+  if  (has('win32') || has('win64'))
+    let cmd = a:bin.' '.a:args.' '.fname
+  else
+    let cmd = shellescape(a:bin).' '.a:args.' '.fname
+  endif
 	if &sh =~ 'cmd\.exe'
 		let cmd = substitute(cmd, '[&()@^<>|]', '^\0', 'g')
 	en


### PR DESCRIPTION
*jsctags* would not work on Windows for me. The `shellescape` function surrounds the `jsctags` cmd with `"`. I observed that this was the error cause. Removing the `"` stop the issue and *jsctags* works as expected. I admit I don't really understand the full extent of this fix. It may not be the best solution. 

I will test the fix on OSX later today and comment back.