### PR TITLE
Docs: do not recommend `--git-dir=%s/.git`

### DIFF
--- a/doc/ctrlp.cnx
+++ b/doc/ctrlp.cnx
@@ -330,7 +330,7 @@ OPTIONS                                                         *ctrlp-options*
 
   " 单个版本控制系统，列出命令列出没有被追踪的文件（较慢）:
   let g:ctrlp_user_command =
-    \ ['.git', 'cd %s && git ls-files . -co --exclude-standard']
+    \ ['.git', 'cd %s && git ls-files -co --exclude-standard']
 
   let g:ctrlp_user_command =
     \ ['.hg', 'hg --cwd %s status -numac -I . $(hg root)'] " MacOSX/Linux

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -340,7 +340,7 @@ Some examples: >
 
   " Single VCS, listing command lists untracked files (slower):
   let g:ctrlp_user_command =
-    \ ['.git', 'cd %s && git ls-files . -co --exclude-standard']
+    \ ['.git', 'cd %s && git ls-files -co --exclude-standard']
 
   let g:ctrlp_user_command =
     \ ['.hg', 'hg --cwd %s status -numac -I . $(hg root)'] " MacOSX/Linux

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ Use `:diffthis` when opening multiple files to run `:diffthis` on the first 4 fi
 * Ignore files in `.gitignore`
     
     ```vim
-      let g:ctrlp_user_command = ['.git/', 'git --git-dir=%s/.git ls-files -oc --exclude-standard']
+      let g:ctrlp_user_command = ['.git', 'cd %s && git ls-files -co --exclude-standard']
     ```
 
 Check `:help ctrlp-options` for other options.


### PR DESCRIPTION
`cd %s && git ls-files` works better in combination with a custom
`ctrlp_root_markers`.