### PR TITLE
Fix most recent used buffer list sorting when using CtrlpBuffers after loading a Vim session.

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1324,7 +1324,16 @@ endf
 fu! s:compmreb(...)
 	" By last entered time (bufnr)
 	let [id1, id2] = [index(s:mrbs, a:1), index(s:mrbs, a:2)]
-	retu id1 == id2 ? 0 : id1 > id2 ? 1 : -1
+	if id1 == id2
+		return 0
+	endif
+	if id1 < 0
+		return 1
+	endif
+	if id2 < 0
+		return -1
+	endif
+	return id1 > id2 ? 1 : -1
 endf
 
 fu! s:compmref(...)


### PR DESCRIPTION
When using the `CtrlPBuffers` command, the most recently used buffers would get push at the end of the suggestion list. This is annoying since when I switch buffers I, most of the time, want to go back to one of the latest buffers I worked on.  

I tried to used `CtrlpMRU` command instead but the list is much longer so the fuzzy search success rate is lower and often gets frustrated. 

Finally, the pull request re-introduce the feature as it was few months ago. I don't know if the current behaviour was intended?! 

Thanks!