### PR TITLE
Separate path correctly for *sh on Windows

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -432,6 +432,9 @@ fu! s:UserCmd(lscmd)
 		let lscmd = substitute(lscmd, '\v(^|\&\&\s*)\zscd (/d)@!', 'cd /d ', '')
 	en
 	let path = exists('*shellescape') ? shellescape(path) : path
+	if (has('win32') || has('win64')) && match(&shell, 'sh') != -1
+		let path = tr(path, '\', '/')
+	en
 	if has('patch-7.4-597') && !(has('win32') || has('win64'))
 		let g:ctrlp_allfiles = systemlist(printf(lscmd, path))
 	else


### PR DESCRIPTION
In user command, `%s` is replaced with a target directory path. On
Windows, this path is always separated by backslashes. If a user
configures `shell` option to `sh` (or something similar), a shell cannot
understand a target directory path and probably cannot list files.

This commit checks the `shell` option on Windows. If this option
contains `sh`, a target directory path is separated by forward slashes.