### PR TITLE
Be more explicit about what windows to replace

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1956,9 +1956,10 @@ fu! s:bufnrfilpath(line)
 endf
 
 fu! ctrlp#normcmd(cmd, ...)
+	let buftypes = [ 'quickfix', 'help' ]
 	if a:0 < 2 && s:nosplit() | retu a:cmd | en
 	let norwins = filter(range(1, winnr('$')),
-		\ 'empty(getbufvar(winbufnr(v:val), "&bt")) || s:isneovimterminal(winbufnr(v:val))')
+		\ 'index(buftypes, getbufvar(winbufnr(v:val), "&bt")) == -1 || s:isneovimterminal(winbufnr(v:val))')
 	for each in norwins
 		let bufnr = winbufnr(each)
 		if empty(bufname(bufnr)) && empty(getbufvar(bufnr, '&ft'))


### PR DESCRIPTION
- Just checking for any buftype is insufficient

- See for example justinmk/vim-dirvish#43 -- a directory buffer should
  have buftype=nofile, but ctrlp should still replace it

- Look instead for buftype=help or buftype=quickfix, explicitly