### PR TITLE
Support f5 refresh in st terminal.

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -953,7 +953,7 @@ fu! s:MapSpecs()
 	if !( exists('s:smapped') && s:smapped == s:bufnr )
 		" Correct arrow keys in terminal
 		if ( has('termresponse') && v:termresponse =~ "\<ESC>" )
-			\ || &term =~? '\vxterm|<k?vt|gnome|screen|linux|ansi|tmux'
+			\ || &term =~? '\vxterm|<k?vt|gnome|screen|linux|ansi|tmux|st(-[-a-z0-9]*)?$'
 			for each in ['\A <up>','\B <down>','\C <right>','\D <left>']
 				exe s:lcmap.' <esc>['.each
 			endfo


### PR DESCRIPTION
Due to the terminal 'st' being left out of a list of hardcoded terminfo
names, the f5 key is not handled properly and will not refresh the
ctrlp window.

This extends the regex to match st, st-256color, st-meta, and
st-meta-256color.

In theory a better approach is to use the terminfo database, but this works for now.

Resolves #242 