### PR TITLE
Fix highlighting for custom ctrlp_line_prefix.

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1754,7 +1754,7 @@ fu! ctrlp#syntax()
 	en
 	sy match CtrlPNoEntries '^ == NO ENTRIES ==$'
 	if hlexists('CtrlPLinePre')
-		sy match CtrlPLinePre '^>'
+		exe "sy match CtrlPLinePre '^".escape(get(g:, 'ctrlp_line_prefix', '>'),'^$.*~\')."'"
 	en
 
 	if s:itemtype == 1 && s:has_conceal


### PR DESCRIPTION
Before this commit, if the user defined `g:ctrlp_line_prefix`, then such
prefix would be shown in every line (while the default prefix is shown
only in the active line). This commit makes a custom prefix behave like
the default one.