### PR TITLE
Fix switching to buffers with protocols

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1941,7 +1941,7 @@ fu! s:isabs(path)
 endf
 
 fu! s:bufnrfilpath(line)
-	if s:isabs(a:line) || a:line =~ '^\~[/\\]'
+	if s:isabs(a:line) || a:line =~ '^\~[/\\]' || a:line =~ '^\w\+:\/\/'
 		let filpath = a:line
 	el
 		let filpath = s:dyncwd.s:lash().a:line


### PR DESCRIPTION
This allows correct switching to buffers with names like scp:// or term://

Fixes #231