### PR TITLE
CtrlPBuffer doesn't correctly display the buffer name and number

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2001,6 +2001,7 @@ fu! s:bufnrfilpath(line)
 			let filpath = bufnr
 		else
 			let bufnr = bufnr(a:line)
+			retu [bufnr, a:line]
 		en
 	en
 	retu [bufnr, filpath]

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1995,9 +1995,13 @@ fu! s:bufnrfilpath(line)
 	en
 	let filpath = fnamemodify(filpath, ':p')
 	let bufnr = bufnr('^'.filpath.'$')
-	if (a:line =~ '[\/]\?\[\d\+\*No Name\]$' && !filereadable(filpath) && bufnr < 1)
-		let bufnr = str2nr(matchstr(a:line, '[\/]\?\[\zs\d\+\ze\*No Name\]$'))
-		let filpath = bufnr
+	if (!filereadable(filpath) && bufnr < 1)
+		if (a:line =~ '[\/]\?\[\d\+\*No Name\]$')
+			let bufnr = str2nr(matchstr(a:line, '[\/]\?\[\zs\d\+\ze\*No Name\]$'))
+			let filpath = bufnr
+		else
+			let bufnr = bufnr(a:line)
+		en
 	en
 	retu [bufnr, filpath]
 endf


### PR DESCRIPTION
CtrlPBuffer doesn't correctly display the buffer name and number if the name points to a non-existing file.

Try open a non-exiting file

```
:e blah/blah/t.txt
```

and you will see that it is displayed as `-1 - [No Name]`
