### PR TITLE
Correct last focused window when PrtExit

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -920,10 +920,13 @@ fu! s:PrtDeleteMRU()
 endf
 
 fu! s:PrtExit()
+	let bw = bufwinnr('%')
 	exe bufwinnr(s:bufnr).'winc w'
 	if bufnr('%') == s:bufnr && bufname('%') == 'ControlP'
 		noa cal s:Close(1)
 		noa winc p
+	els
+		exe bw.'winc w'
 	en
 endf
 


### PR DESCRIPTION
Related issue https://github.com/ctrlpvim/ctrlp.vim/issues/235
