### PR TITLE
Reorder binary lookup to respect PATH

### DIFF
--- a/autoload/ctrlp/buffertag.vim
+++ b/autoload/ctrlp/buffertag.vim
@@ -35,9 +35,9 @@ let s:bins = [
 	\ 'ctags-exuberant',
 	\ 'exuberant-ctags',
 	\ 'exctags',
+	\ 'ctags',
 	\ '/usr/local/bin/ctags',
 	\ '/opt/local/bin/ctags',
-	\ 'ctags',
 	\ 'ctags.exe',
 	\ 'tags',
 	\ ]


### PR DESCRIPTION
The buffertag plugin prefers the ctags binary in either `/usr/local/bin` or `/opt/local/bin` to the one found by PATH lookup.