### PR TITLE
Fix default mode and mode names when g:ctrlp_types is customized.

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2562,6 +2562,10 @@ fu! ctrlp#init(type, ...)
 	cal s:SetWD(a:0 ? a:1 : {})
 	cal s:MapNorms()
 	cal s:MapSpecs()
+	if empty(g:ctrlp_types) && empty(g:ctrlp_ext_vars)
+		call ctrlp#exit()
+		retu
+	en
 	if type(a:type) == 0
 		let type = a:type
 	el

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -212,11 +212,13 @@ el
 en
 let g:ctrlp_builtins = len(g:ctrlp_types)-1
 
-let s:coretypes = filter([
-	\ ['files', 'fil'],
-	\ ['buffers', 'buf'],
-	\ ['mru files', 'mru'],
-\ ], 'index(g:ctrlp_types, v:val[1])!=-1')
+let s:coretype_names = {
+	\ 'fil' : 'files',
+	\ 'buf' : 'buffers',
+	\ 'mru' : 'mru files',
+	\ }
+
+let s:coretypes = map(copy(g:ctrlp_types), '[s:coretype_names[v:val], v:val]')
 
 " Get the options {{{2
 fu! s:opts(...)

--- a/plugin/ctrlp.vim
+++ b/plugin/ctrlp.vim
@@ -17,7 +17,7 @@ let [g:ctrlp_lines, g:ctrlp_allfiles, g:ctrlp_alltags, g:ctrlp_alldirs,
 if !exists('g:ctrlp_map') | let g:ctrlp_map = '<c-p>' | en
 if !exists('g:ctrlp_cmd') | let g:ctrlp_cmd = 'CtrlP' | en
 
-com! -n=? -com=dir CtrlP         cal ctrlp#init('fil', { 'dir': <q-args> })
+com! -n=? -com=dir CtrlP         cal ctrlp#init(0, { 'dir': <q-args> })
 com! -n=? -com=dir CtrlPMRUFiles cal ctrlp#init('mru', { 'dir': <q-args> })
 
 com! -bar CtrlPBuffer   cal ctrlp#init('buf')


### PR DESCRIPTION
When the user customized g:ctrlp_types to use a custom core mode set (possibly
with a custom relative order), the default mode (used when a bare :CtrlP is
issued) is wrong, along with the descriptive names of modes displayed in the
statusline. This pull request fixes these issues.

Fixes #309.