### PR TITLE
set ctrlp buffer's filetype

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2579,6 +2579,7 @@ fu! ctrlp#init(type, ...)
 	en
 	cal ctrlp#setlines(s:settype(type))
 	cal ctrlp#syntax()
+	set ft=ctrlp
 	cal s:SetDefTxt()
 	let curName = s:CurTypeName()
 	let shouldExitSingle = index(s:opensingle, curName[0])>=0 || index(s:opensingle, curName[1])>=0


### PR DESCRIPTION
Dear ctrlp developer. I think setting ctrlp's buffer filetype might help users and other developers find easier way to customize ctrlp. For example, adding sytnax highlight to text elements that not provided by ctrlp's API is easier.

A usage is vim-devicon. Icon highlight can be added ad poc easily by just adding `syntax/ctrlp.vim` to runtime path.

![screenshot from 2016-10-21 20-41-53](https://cloud.githubusercontent.com/assets/2883231/19598784/52fb9b8a-97cf-11e6-852d-8c7f8a8752d1.png)
