### PR TITLE
filter duplicates on g:ctrlp_lines while preserving order

### DIFF
--- a/autoload/ctrlp/mixed.vim
+++ b/autoload/ctrlp/mixed.vim
@@ -65,7 +65,7 @@ fu! s:getnewmix(cwd, clim)
 		cal sort(g:ctrlp_lines, 'ctrlp#complen')
 	en
 	" remove duplicates from the final result set
-  let g:ctrlp_lines=filter(copy(g:ctrlp_lines), 'index(g:ctrlp_lines, v:val, v:key+1)==-1')
+	let g:ctrlp_lines=filter(copy(g:ctrlp_lines), 'index(g:ctrlp_lines, v:val, v:key+1)==-1')
 	let g:ctrlp_allmixes = { 'filtime': getftime(ctrlp#utils#cachefile()),
 		\ 'mrutime': getftime(ctrlp#mrufiles#cachefile()), 'cwd': a:cwd,
 		\ 'bufs': len(ctrlp#mrufiles#bufs()), 'data': g:ctrlp_lines }

--- a/autoload/ctrlp/mixed.vim
+++ b/autoload/ctrlp/mixed.vim
@@ -64,6 +64,8 @@ fu! s:getnewmix(cwd, clim)
 	if len(g:ctrlp_lines) <= a:clim
 		cal sort(g:ctrlp_lines, 'ctrlp#complen')
 	en
+	" remove duplicates from the final result set
+  let g:ctrlp_lines=filter(copy(g:ctrlp_lines), 'index(g:ctrlp_lines, v:val, v:key+1)==-1')
 	let g:ctrlp_allmixes = { 'filtime': getftime(ctrlp#utils#cachefile()),
 		\ 'mrutime': getftime(ctrlp#mrufiles#cachefile()), 'cwd': a:cwd,
 		\ 'bufs': len(ctrlp#mrufiles#bufs()), 'data': g:ctrlp_lines }


### PR DESCRIPTION
This closes https://github.com/ctrlpvim/ctrlp.vim/issues/314, https://github.com/ctrlpvim/ctrlp.vim/issues/168

This may not be the best implementation, but it should only affect performance when refreshing a very large `:CtrlPMixed` lists.

I have very little experience with vimL, the project code hasn't been easy for me to understand, I'm not very sure where and how to implement this at all, I'll be glad to take any advises and fix up my commit.

@mattn 