### PR TITLE
Initialize the MRU plugin only when needed

### DIFF
--- a/plugin/ctrlp.vim
+++ b/plugin/ctrlp.vim
@@ -39,7 +39,9 @@ if g:ctrlp_map != '' && !hasmapto('<plug>(ctrlp)')
 	exe 'map' g:ctrlp_map '<plug>(ctrlp)'
 en
 
-cal ctrlp#mrufiles#init()
+if index(g:ctrlp_types, 'mru') >= 0
+	cal ctrlp#mrufiles#init()
+en
 
 com! -bar CtrlPTag      cal ctrlp#init(ctrlp#tag#id())
 com! -bar CtrlPQuickfix cal ctrlp#init(ctrlp#quickfix#id())


### PR DESCRIPTION
There's no point in tracking the files if the MRU plugin has been
explicitly disabled.