### PR TITLE
Add g:ctrlp_path_sort option.

### DIFF
--- a/autoload/ctrlp/line.vim
+++ b/autoload/ctrlp/line.vim
@@ -10,12 +10,18 @@ if exists('g:loaded_ctrlp_line') && g:loaded_ctrlp_line
 en
 let g:loaded_ctrlp_line = 1
 
+let s:sort = 1
+if exists('g:ctrlp_line_sort')
+	let s:sort = g:ctrlp_line_sort
+en
+
 cal add(g:ctrlp_ext_vars, {
 	\ 'init': 'ctrlp#line#init(s:crbufnr)',
 	\ 'accept': 'ctrlp#line#accept',
 	\ 'lname': 'lines',
 	\ 'sname': 'lns',
 	\ 'type': 'tabe',
+	\ 'sort': s:sort,
 	\ })
 
 let s:id = g:ctrlp_builtins + len(g:ctrlp_ext_vars)


### PR DESCRIPTION
It is possible to replace with "line" standard search.
This patch allows to specify:

    let g:ctrlp_path_sort = 0

to return unsorted list of lines.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>