### PR TITLE
Add g:ctrlp_regex_always_higlight option

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1873,6 +1873,11 @@ fu! s:highlight(pat, grp)
 		en
 
 		cal matchadd('CtrlPLinePre', '^>')
+	elseif !empty(a:pat) && s:regexp &&
+				\ exists('g:ctrlp_regex_always_higlight') &&
+				\ g:ctrlp_regex_always_higlight
+		let pat = substitute(a:pat, '\\\@<!\^', '^> \\zs', 'g')
+		cal matchadd(a:grp, ( s:martcs == '' ? '\c' : '\C').pat)
 	en
 endf
 


### PR DESCRIPTION
CtrlP highlights only path and files as you type pattern.  Other
extensions, such as 'lines' or 'tags' do not have highlighting as you
type search pattern.  With this patch other other extensions also can
have pattern highlighting. For this, it is necessary to add:

    let g:ctrlp_regex_always_higlight = 1

This patch works only when: g:ctrlp_regexp = 1. Which is quite safe as
universal approach.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>