### PR TITLE
Update 'line' extension to act as Vim search pattern.

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1201,7 +1201,7 @@ fu! s:AcceptSelection(action)
 			let type = exttype == 'dict' ? exttype : 'list'
 		en
 	en
-	let actargs = type == 'dict' ? [{ 'action': md, 'line': line, 'icr': icr }]
+	let actargs = type == 'dict' ? [{ 'action': md, 'line': line, 'icr': icr, 'input': str}]
 		\ : [md, line]
 	cal call(actfunc, actargs)
 endf

--- a/autoload/ctrlp/line.vim
+++ b/autoload/ctrlp/line.vim
@@ -13,6 +13,7 @@ let g:loaded_ctrlp_line = 1
 cal add(g:ctrlp_ext_vars, {
 	\ 'init': 'ctrlp#line#init(s:crbufnr)',
 	\ 'accept': 'ctrlp#line#accept',
+	\ 'act_farg' : 'dict',
 	\ 'lname': 'lines',
 	\ 'sname': 'lns',
 	\ 'type': 'tabe',
@@ -50,11 +51,17 @@ fu! ctrlp#line#init(bufnr)
 	retu lines
 endf
 
-fu! ctrlp#line#accept(mode, str)
-	let info = matchlist(a:str, '\t|[^|]\+|\(\d\+\):\(\d\+\)|$')
+fu! ctrlp#line#accept(dict)
+	let mode = a:dict['action']
+	let str = a:dict['line']
+	let input = a:dict['input']
+	let info = matchlist(str, '\t|[^|]\+|\(\d\+\):\(\d\+\)|$')
 	let bufnr = str2nr(get(info, 1))
 	if bufnr
-		cal ctrlp#acceptfile(a:mode, bufnr, get(info, 2))
+		cal ctrlp#acceptfile(mode, bufnr, get(info, 2))
+		let @/ = input
+		call search(input, 'c')
+		call histadd("search", input)
 	en
 endf
 


### PR DESCRIPTION
With this patch:

 - Typed pattern becomes search pattern in Vim.
 - Cursors jumps directly to matched word. (Without this patch cursor
   jumps only to matched line).
 - User can press "n" or "N" to jump next/previous matched pattern.
   While pressing "n" / "N" matched pattern got highlighted.

Signed-off-by: Andrei Stepanov <astepano@redhat.com>