### PR TITLE
Fix issue with CtrlPLine and empty search string

### DIFF
--- a/autoload/ctrlp/line.vim
+++ b/autoload/ctrlp/line.vim
@@ -59,9 +59,11 @@ fu! ctrlp#line#accept(dict)
 	let bufnr = str2nr(get(info, 1))
 	if bufnr
 		cal ctrlp#acceptfile(mode, bufnr, get(info, 2))
-		let @/ = input
-		call search(input, 'c')
-		call histadd("search", input)
+		if !empty(input)
+			let @/ = input
+			call search(input, 'c')
+			call histadd("search", input)
+		en
 	en
 endf
 


### PR DESCRIPTION
When navigating to a line and selecting it (without entering a search
string), vim would report "E35: No previous regular expression".