### PR TITLE
Perform lazy update only on delete

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -68,6 +68,7 @@ let [s:pref, s:bpref, s:opts, s:new_opts, s:lc_opts] =
 	\ 'jump_to_buffer':        ['s:jmptobuf', 'Et'],
 	\ 'key_loop':              ['s:keyloop', 0],
 	\ 'lazy_update':           ['s:lazy', 0],
+	\ 'lazy_del':              ['s:lazy_del', 0],
 	\ 'match_func':            ['s:matcher', {}],
 	\ 'match_window':          ['s:mw', ''],
 	\ 'match_window_bottom':   ['s:mwbottom', 1],
@@ -270,6 +271,9 @@ fu! s:opts(...)
 	en
 	if s:lazy
 		cal extend(s:glbs, { 'ut': ( s:lazy > 1 ? s:lazy : 250 ) })
+	en
+	if s:lazy_del
+		cal extend(s:glbs, { 'ut': ( s:lazy_del > 1 ? s:lazy_del : 250 ) })
 	en
 	" Extensions
 	if !( exists('extensions') && extensions == s:extensions )
@@ -693,6 +697,7 @@ endf
 fu! s:ForceUpdate()
 	let pos = exists('*getcurpos') ? getcurpos() : getpos('.')
 	sil! cal s:Update(escape(s:getinput(), '\'))
+	let input = s:getinput()
 	cal setpos('.', pos)
 endf
 
@@ -758,7 +763,11 @@ fu! s:PrtBS()
 	en
 	unl! s:hstgot
 	let [s:prompt[0], s:matches] = [substitute(s:prompt[0], '.$', '', ''), 1]
-	cal s:BuildPrompt(1)
+	if s:lazy_del
+		cal s:BuildPrompt(0)
+	el
+		cal s:BuildPrompt(1)
+	en
 endf
 
 fu! s:PrtDelete()
@@ -767,7 +776,11 @@ fu! s:PrtDelete()
 	let [prt, s:matches] = [s:prompt, 1]
 	let prt[1] = matchstr(prt[2], '^.')
 	let prt[2] = substitute(prt[2], '^.', '', '')
-	cal s:BuildPrompt(1)
+	if s:lazy_del
+		cal s:BuildPrompt(0)
+	el
+		cal s:BuildPrompt(1)
+	en
 endf
 
 fu! s:PrtDeleteWord()
@@ -779,7 +792,11 @@ fu! s:PrtDeleteWord()
 		\ : str =~ '\s\+$' ? matchstr(str, '^.*\S\ze\s\+$')
 		\ : str =~ '\v^(\S+|\s+)$' ? '' : str
 	let s:prompt[0] = str
-	cal s:BuildPrompt(1)
+	if s:lazy_del
+		cal s:BuildPrompt(0)
+	el
+		cal s:BuildPrompt(1)
+	en
 endf
 
 fu! s:PrtInsert(...)
@@ -2644,7 +2661,7 @@ fu! s:autocmds()
 	if exists('#CtrlPLazy')
 		au! CtrlPLazy
 	en
-	if s:lazy
+	if s:lazy || s:lazy_del
 		aug CtrlPLazy
 			au!
 			au CursorHold ControlP cal s:ForceUpdate()


### PR DESCRIPTION
In large project, Ctrlp becomes very slow when I press BackSpace.
The `ctrlp_lazy_update` option performs lazy update on both forward and backward input.
I don't need lazy update on forward input because it's very smooth when I type a file name.
So I add `ctrlp_lazy_del` option, It performs lazy update only when user delete some characters.