### PR TITLE
Fixes #450

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2618,7 +2618,7 @@ fu! ctrlp#init(type, ...)
 		en
 	en
 	cal ctrlp#setlines(s:settype(type))
-	set ft=ctrlp
+	let &filetype = empty(&filetype) ? 'ctrlp' : 'ctrlp.' . &filetype
 	cal ctrlp#syntax()
 	cal s:SetDefTxt()
 	let curName = s:CurTypeName()


### PR DESCRIPTION
File types that is set by any CtrlP extensions should be respected.
Normally, the file type will be `ctrlp`, but it will be a combined file type like `ctrlp.vim`, `ctrlp.go` etc. if a CtrlP extension is set file types for CtrlP buffer.