### PR TITLE
Fix filetype is set to multiple ctrlps

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2602,7 +2602,7 @@ fu! s:IsBuiltin()
 endfu
 
 fu! s:DetectFileType(type, ft)
-	if s:IsBuiltin() || empty(a:ft)
+	if s:IsBuiltin() || empty(a:ft) || a:ft ==# 'ctrlp'
 		retu 'ctrlp'
 	el
 		retu 'ctrlp.' . a:ft


### PR DESCRIPTION
The problem is:
1. filetype is 'ctrlp'
2. invoking an extension and it doesn't set filetype
3. then filetype is set to 'ctrlp.ctrlp'
The filetype should be just 'ctrlp' in this case.