### PR TITLE
Fix issue #421

### DIFF
--- a/autoload/ctrlp/buffertag.vim
+++ b/autoload/ctrlp/buffertag.vim
@@ -205,7 +205,8 @@ fu! s:parseline(line)
 	let vals = matchlist(a:line,
 		\ '\v^([^\t]+)\t(.+)\t[?/]\^?(.{-1,})\$?[?/]\;\"\t(.+)\tline(no)?\:(\d+)')
 	if vals == [] | retu '' | en
-	let [bufnr, bufname] = [bufnr('^'.vals[2].'$'), fnamemodify(vals[2], ':p:t')]
+  let fname = substitute(vals[2], '\\\\', '/', 'g')
+	let [bufnr, bufname] = [bufnr('^'.fname.'$'), fnamemodify(fname, ':p:t')]
 	retu vals[1].'	'.vals[4].'|'.bufnr.':'.bufname.'|'.vals[6].'| '.vals[3]
 endf
 


### PR DESCRIPTION
On Windows, universal-ctags escapes backslashes in filenames with another backslash. For example, a filename in a tags file may appear as `C:\\tmp\\test.cpp` whereas Exuberant Ctags would write the filename as `C:\tmp\test.cpp`. This would cause `bufnr()` function calls for those filenames to fail.

My solution is to replace the double backslashes with single forward slashes before passing the filenames to `bufnr`.