### PR TITLE
Only call 'cd' if needed after opening file

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1789,7 +1789,10 @@ endf
 
 fu! ctrlp#setdir(path, ...)
 	let cmd = a:0 ? a:1 : 'lc!'
-	sil! exe cmd s:fnesc(a:path, 'c')
+	let newcwd = s:fnesc(a:path, 'c')
+	if getcwd(0) != newcwd
+		sil! exe cmd newcwd
+	end
 	let [s:crfilerel, s:dyncwd] = [fnamemodify(s:crfile, ':.'), getcwd()]
 endf
 " Fallbacks {{{3


### PR DESCRIPTION
I discovered that calling `:cd <path>` can actually change the name of the current buffer if the path to the buffer traverses symbolic links. An example:

```
$ mkdir test && cd test
$ mkdir real
$ touch real/file.txt
$ ln -s real symbolic
$ vim symbolic/file.txt
```
If you then execute a `:cd .` you will see the path of the current buffer jump from `symbolic/file.txt` to `real/file.txt`. The way my project is currently set up, it is very important that the buffer names be representative of the symbolic paths that I use to access them. I wish there was a better way to disable this behavior, but for my purposes simply preventing a no-op cd works well enough.