### PR TITLE
Fix E94 on selecting a file when there is only one help window

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1128,8 +1128,9 @@ fu! ctrlp#acceptfile(...)
 	cal s:PrtExit()
 	let tail = s:tail()
 	let j2l = atl != '' ? atl : matchstr(tail, '^ +\zs\d\+$')
+	let openmyself = bufnr == bufnr('%')
 	if bufnr > 0 && ( !empty(s:jmptobuf) && s:jmptobuf =~ md )
-		\ && !( md == 'e' && bufnr == bufnr('%') )
+		\ && !( md == 'e' && openmyself )
 		let [jmpb, bufwinnr] = [1, bufwinnr(bufnr)]
 		let buftab = ( s:jmptobuf =~# '[tTVH]' || s:jmptobuf > 1 )
 			\ ? s:buftab(bufnr, md) : [0, 0]
@@ -1146,12 +1147,12 @@ fu! ctrlp#acceptfile(...)
 		if j2l | cal ctrlp#j2l(j2l) | en
 	el
 		" Determine the command to use
-		let useb = bufnr > 0 && buflisted(bufnr) && ( empty(tail) || useb )
+		let useb = bufnr > 0 && ( buflisted(bufnr) || openmyself ) && ( empty(tail) || useb )
 		let cmd =
 			\ md == 't' || s:splitwin == 1 ? ( useb ? 'tab sb' : 'tabe' ) :
 			\ md == 'h' || s:splitwin == 2 ? ( useb ? 'sb' : 'new' ) :
 			\ md == 'v' || s:splitwin == 3 ? ( useb ? 'vert sb' : 'vne' ) :
-			\ &bt == 'help' ? 'b' :
+			\ &bt == 'help' && openmyself ? 'b' :
 			\ call('ctrlp#normcmd', useb ? ['b', 'bo vert sb'] : ['e'])
 		" Reset &switchbuf option
 		let [swb, &swb] = [&swb, '']


### PR DESCRIPTION
# Summary
Fix E94 on selecting a file when there is only one help window.
# How to recreate
1. `vim -c 'help | only'`
1. `:CtrlPMRUFiles` or another CtrlP command
1. Select any file
1. E94 occurs
# Cause
#444 has changed the behavior when the current buffer type is 'help' so that s:openfile() would always use 'b' command. This works well for `:CtrlPBufTag`, but doesn't work for other commands like `:CtrlPMRUFiles`.
```vim
let cmd =
  \ md == 't' || s:splitwin == 1 ? ( useb ? 'tab sb' : 'tabe' ) :
  \ md == 'h' || s:splitwin == 2 ? ( useb ? 'sb' : 'new' ) :
  \ md == 'v' || s:splitwin == 3 ? ( useb ? 'vert sb' : 'vne' ) :
  \ &bt == 'help' ? 'b' :
  \ call('ctrlp#normcmd', useb ? ['b', 'bo vert sb'] : ['e'])
```
# Fix
Use 'b' only if the current buffer type is 'help' and the opening file is the help file itself. Otherwise, use ctrlp#normcmd() function as before. (ctrlp#normcmd() looks for a available normal window to open the file and assumes that a window for 'help' is not available, so, #444 (#437) occurs.)

I also found that md == 't' \<c-t>, md == 'h' \<c-x> and md == 'v' \<c-v> doesn't work for `:CtrlPBufTag`. So I created `l:openmyself` to set `l:useb` correctly.

# Validation
- E94
    - E94 occurs without the patch with the above sequence.
    - E94 doesn't occur with the patch with the above sequence.
- #437 
    - #437 doesn't occur without the patch.
    - #437 doesn't occur with the patch.
- Other opening methods (\<c-t>, \<c-x> and \<c-v>)
    - Other opening methods doesn't work for `:CtrlPBufTag` without the patch.
    - Other opening methods work well for `:CtrlPBufTag` with the patch.
