### PR TITLE
Kick up max_files default 10k → 50k

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -73,7 +73,7 @@ let [s:pref, s:bpref, s:opts, s:new_opts, s:lc_opts] =
 	\ 'match_window_bottom':   ['s:mwbottom', 1],
 	\ 'match_window_reversed': ['s:mwreverse', 1],
 	\ 'max_depth':             ['s:maxdepth', 40],
-	\ 'max_files':             ['s:maxfiles', 10000],
+	\ 'max_files':              ['s:maxfiles', 50000],
 	\ 'max_height':            ['s:mxheight', 10],
 	\ 'max_history':           ['s:maxhst', exists('+hi') ? &hi : 20],
 	\ 'mruf_default_order':    ['s:mrudef', 0],


### PR DESCRIPTION
Hi!

I do understand that anyone can `let g:ctrlp_max_files = 50000` or whatever in their own vimrc. [Many people do][•] change that.

However, I sincerely believe that 10k files is way too low for such an awesome plugin.

You see, it isn't hard to navigate a small repo. The project is already a mess at the point when you reach out for "bigger tools" like CtrlP. Further, when you do pull out those tools, you usually want them *to work*. Nobody likes unreliable tools.

To substantiate, here I have a Linux kernel tree of a particular version. Cloc says, there're `46715 text files.` **46k files**. Sure enough, as I went with the defaults, many files *I know are there* fail to be found via CtrlP. This undermines my trust in the tool; besides frustrating, I immediately recount the previous occurrences the tool failed on me, and just start wanting ever more to ditch it and find something else.

I bet, too many people will, irrationally or not, go the ditching route — rather than go distract themselves with config reading and option tweaking. Even less so, submitting PRs.

So, well... I know, changing defaults is often met with reluctance. But you have no risk here. Just raise the limit... please. This line hasn't been touched since 2012!

Thanks in advance, and solid gratitude for what you do.

[•]: https://github.com/search?q=let+g%3Actrlp_max_files&type=Code