### PR TITLE
Fix g:ctrlp_switch_buffer setting in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,10 +50,10 @@ Use `:diffthis` when opening multiple files to run `:diffthis` on the first 4 fi
     let g:ctrlp_working_path_mode = 'ra'
     ```
 
-    `'c'` - the directory of the current file.  
-    `'a'` - the directory of the current file, unless it is a subdirectory of the cwd  
-    `'r'` - the nearest ancestor of the current file that contains one of these directories or files: `.git` `.hg` `.svn` `.bzr` `_darcs`  
-    `'w'` - modifier to "r": start search from the cwd instead of the current file's directory  
+    `'c'` - the directory of the current file.
+    `'a'` - the directory of the current file, unless it is a subdirectory of the cwd
+    `'r'` - the nearest ancestor of the current file that contains one of these directories or files: `.git` `.hg` `.svn` `.bzr` `_darcs`
+    `'w'` - modifier to "r": start search from the cwd instead of the current file's directory
     `0` or `''` (empty string) - disable this feature.
 
     If none of the default markers (`.git` `.hg` `.svn` `.bzr` `_darcs`) are present in a project, you can define additional ones with `g:ctrlp_root_markers`:
@@ -66,7 +66,7 @@ Use `:diffthis` when opening multiple files to run `:diffthis` on the first 4 fi
 
 * If a file is already open, open it again in a new pane instead of switching to the existing pane
 
-    `let g:ctrlp_switch_buffer = 'et'`
+    `let g:ctrlp_switch_buffer = 0`
 
 * Exclude files and directories using Vim's `wildignore` and CtrlP's own `g:ctrlp_custom_ignore`. If a custom listing command is being used, exclusions are ignored:
 
@@ -90,7 +90,7 @@ Use `:diffthis` when opening multiple files to run `:diffthis` on the first 4 fi
     ```
 
 * Ignore files in `.gitignore`
-    
+
     ```vim
       let g:ctrlp_user_command = ['.git', 'cd %s && git ls-files -co --exclude-standard']
     ```


### PR DESCRIPTION
In the existing docs, let g:ctrlp_switch_buffer = 'et' is suggested to open the buffer in the current pane instead of switching to the existing pane. This actually only opens the buffer if in a new tab. let g:ctrlp_switch_buffer = 0 will open the buffer in the current pane.