### PR TITLE
Fix arrow keys when using true color config

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1065,7 +1065,7 @@ fu! s:MapSpecs()
 	if !( exists('s:smapped') && s:smapped == s:bufnr )
 		" Correct arrow keys in terminal
 		if ( has('termresponse') && v:termresponse =~ "\<ESC>" )
-			\ || &term =~? '\vxterm|<k?vt|gnome|screen|linux|ansi|tmux|st(-[-a-z0-9]*)?$'
+			\ || &term =~? '\vxterm|<k?vt|gnome|screen|linux|ansi|tmux|st(-[-a-z0-9]*)?(\:tc)?$'
 			for each in ['\A <up>','\B <down>','\C <right>','\D <left>']
 				exe s:lcmap.' <esc>['.each
 			endfo


### PR DESCRIPTION
I notice the arrow keys doesn't work when setting `tmux` to use _true color_, required for some color schemes.

This PR fix that by allowing the `:Tc` suffix in the term regex.

More info at:

- https://github.com/rakr/vim-one#tmux-support
- http://homeonrails.com/2016/05/truecolor-in-gnome-terminal-tmux-and-neovim/

My (g)vim version:

```
local/gvim 8.1.2102-1
    Vi Improved, a highly configurable, improved version of the vi text editor (with advanced features, such as a GUI)
local/vim-runtime 8.1.2102-1
    Vi Improved, a highly configurable, improved version of the vi text editor (shared runtime)
```