### PR TITLE
add async api support

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2734,9 +2734,28 @@ fu! ctrlp#init(type, ...)
 		return 0
 	en
 	cal s:BuildPrompt(1)
+
+	call s:createEventContext()
+	call s:notifyEvent('init')
+
 	if s:keyloop | cal s:KeyLoop() | en
 	return 1
 endf
+
+" - Events {{{1
+fu! s:createEventContext()
+	let s:ectx = {}
+	let s:event = s:getextvar('event')
+endfu
+
+fu! s:notifyEvent(type)
+	if s:event != -1
+		let s:etype = a:type
+		call eval(s:event)
+		let s:etype = ''
+	endif
+endfu
+
 " - Autocmds {{{1
 if has('autocmd')
 	aug CtrlPAug

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2755,7 +2755,7 @@ endf
 
 fu! ctrlp#set(lines)
 	let g:ctrlp_lines = a:lines
-endfu
+endf
 
 fu! ctrlp#get()
 	retu g:ctrlp_lines

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2758,7 +2758,7 @@ fu! ctrlp#set(lines)
 endfu
 
 fu! ctrlp#get()
-	return g:ctrlp_lines
+	retu g:ctrlp_lines
 endfu
 
 fu! ctrlp#update()

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -790,6 +790,9 @@ fu! s:BuildPrompt(upd)
 	if empty(prt[1]) && s:focus
 		exe 'echoh' hibase '| echon "_" | echoh None'
 	en
+	if a:upd
+		call s:notifyChange()
+	en
 endf
 " - SetDefTxt() {{{1
 fu! s:SetDefTxt()
@@ -2609,6 +2612,10 @@ fu! ctrlp#clearmarkedlist()
 	let s:marked = {}
 endf
 
+fu! ctrlp#input()
+	return s:getinput()
+endf
+
 fu! ctrlp#exit()
 	cal s:PrtExit()
 endf
@@ -2734,26 +2741,16 @@ fu! ctrlp#init(type, ...)
 		return 0
 	en
 	cal s:BuildPrompt(1)
-
-	call s:createEventContext()
-	call s:notifyEvent('init')
-
 	if s:keyloop | cal s:KeyLoop() | en
 	return 1
 endf
 
 " - Events {{{1
-fu! s:createEventContext()
-	let s:ectx = {}
-	let s:event = s:getextvar('event')
-endfu
-
-fu! s:notifyEvent(type)
-	if s:event != -1
-		let s:etype = a:type
-		call eval(s:event)
-		let s:etype = ''
-	endif
+fu! s:notifyChange()
+	let l:cb = s:getextvar('change')
+	if l:cb != -1
+		call eval(l:cb)
+	en
 endfu
 
 " - Autocmds {{{1

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2763,7 +2763,7 @@ endf
 
 fu! ctrlp#update()
 	cal s:ForceUpdate()
-endfu
+endf
 
 " - Autocmds {{{1
 if has('autocmd')

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2759,7 +2759,7 @@ endfu
 
 fu! ctrlp#get()
 	retu g:ctrlp_lines
-endfu
+endf
 
 fu! ctrlp#update()
 	cal s:ForceUpdate()

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2762,7 +2762,7 @@ fu! ctrlp#get()
 endfu
 
 fu! ctrlp#update()
-	call s:ForceUpdate()
+	cal s:ForceUpdate()
 endfu
 
 " - Autocmds {{{1

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -791,7 +791,7 @@ fu! s:BuildPrompt(upd)
 		exe 'echoh' hibase '| echon "_" | echoh None'
 	en
 	if a:upd
-		cal s:notifySearch()
+		cal s:NotifySearch()
 	en
 endf
 " - SetDefTxt() {{{1
@@ -2746,7 +2746,7 @@ fu! ctrlp#init(type, ...)
 endf
 
 " - Events {{{1
-fu! s:notifySearch()
+fu! s:NotifySearch()
 	let l:cb = s:getextvar('search')
 	if l:cb != -1
 		cal eval(l:cb)

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -791,7 +791,7 @@ fu! s:BuildPrompt(upd)
 		exe 'echoh' hibase '| echon "_" | echoh None'
 	en
 	if a:upd
-		cal s:notifyChange()
+		cal s:notifySearch()
 	en
 endf
 " - SetDefTxt() {{{1
@@ -2746,8 +2746,8 @@ fu! ctrlp#init(type, ...)
 endf
 
 " - Events {{{1
-fu! s:notifyChange()
-	let l:cb = s:getextvar('change')
+fu! s:notifySearch()
+	let l:cb = s:getextvar('search')
 	if l:cb != -1
 		cal eval(l:cb)
 	en

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2742,7 +2742,7 @@ fu! ctrlp#init(type, ...)
 	en
 	cal s:BuildPrompt(1)
 	if s:keyloop | cal s:KeyLoop() | en
-	return 1
+	retu 1
 endf
 
 " - Events {{{1

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2751,7 +2751,7 @@ fu! s:notifyChange()
 	if l:cb != -1
 		cal eval(l:cb)
 	en
-endfu
+endf
 
 fu! ctrlp#set(lines)
 	let g:ctrlp_lines = a:lines

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2613,7 +2613,7 @@ fu! ctrlp#clearmarkedlist()
 endf
 
 fu! ctrlp#input()
-	return s:getinput()
+	retu s:getinput()
 endf
 
 fu! ctrlp#exit()

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -791,7 +791,7 @@ fu! s:BuildPrompt(upd)
 		exe 'echoh' hibase '| echon "_" | echoh None'
 	en
 	if a:upd
-		call s:notifyChange()
+		cal s:notifyChange()
 	en
 endf
 " - SetDefTxt() {{{1

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2753,6 +2753,18 @@ fu! s:notifyChange()
 	en
 endfu
 
+fu! ctrlp#set(lines)
+	let g:ctrlp_lines = a:lines
+endfu
+
+fu! ctrlp#get()
+	return g:ctrlp_lines
+endfu
+
+fu! ctrlp#update()
+	call s:ForceUpdate()
+endfu
+
 " - Autocmds {{{1
 if has('autocmd')
 	aug CtrlPAug

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2753,14 +2753,6 @@ fu! s:notifyChange()
 	en
 endf
 
-fu! ctrlp#set(lines)
-	let g:ctrlp_lines = a:lines
-endf
-
-fu! ctrlp#get()
-	retu g:ctrlp_lines
-endf
-
 fu! ctrlp#update()
 	cal s:ForceUpdate()
 endf

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2749,7 +2749,7 @@ endf
 fu! s:notifyChange()
 	let l:cb = s:getextvar('change')
 	if l:cb != -1
-		call eval(l:cb)
+		cal eval(l:cb)
 	en
 endfu
 

--- a/autoload/ctrlp/line.vim
+++ b/autoload/ctrlp/line.vim
@@ -12,6 +12,7 @@ let g:loaded_ctrlp_line = 1
 
 cal add(g:ctrlp_ext_vars, {
 	\ 'init': 'ctrlp#line#init(s:crbufnr)',
+	\ 'event': 'ctrlp#line#event(s:etype, s:ectx)',
 	\ 'accept': 'ctrlp#line#accept',
 	\ 'act_farg' : 'dict',
 	\ 'lname': 'lines',
@@ -77,5 +78,9 @@ fu! ctrlp#line#cmd(mode, ...)
 	retu s:id
 endf
 "}}}
+
+fu! ctrlp#line#event(etype, ectx)
+	echom a:etype
+endf
 
 " vim:fen:fdm=marker:fmr={{{,}}}:fdl=0:fdc=1:ts=2:sw=2:sts=2

--- a/autoload/ctrlp/line.vim
+++ b/autoload/ctrlp/line.vim
@@ -79,13 +79,11 @@ fu! ctrlp#line#cmd(mode, ...)
 endf
 "}}}
 
-let s:i = 0
+let s:months= ["January","February","March","April","May","June","July","August","September","October","November","December"]
 fu! ctrlp#line#change()
-	let s:i += 1
-	echom s:i . ' ' . ctrlp#input()
-	if s:i == 10
-		call ctrlp#exit()
-	en
+	let l:input = ctrlp#input()
+	call ctrlp#set(filter(copy(s:months), 'v:val =~ l:input'))
+	call ctrlp#update()
 endf
 
 " vim:fen:fdm=marker:fmr={{{,}}}:fdl=0:fdc=1:ts=2:sw=2:sts=2

--- a/autoload/ctrlp/line.vim
+++ b/autoload/ctrlp/line.vim
@@ -12,7 +12,6 @@ let g:loaded_ctrlp_line = 1
 
 cal add(g:ctrlp_ext_vars, {
 	\ 'init': 'ctrlp#line#init(s:crbufnr)',
-	\ 'change': 'ctrlp#line#change()',
 	\ 'accept': 'ctrlp#line#accept',
 	\ 'act_farg' : 'dict',
 	\ 'lname': 'lines',
@@ -78,12 +77,5 @@ fu! ctrlp#line#cmd(mode, ...)
 	retu s:id
 endf
 "}}}
-
-let s:months= ["January","February","March","April","May","June","July","August","September","October","November","December"]
-fu! ctrlp#line#change()
-	let l:input = ctrlp#input()
-	call ctrlp#set(filter(copy(s:months), 'v:val =~ l:input'))
-	call ctrlp#update()
-endf
 
 " vim:fen:fdm=marker:fmr={{{,}}}:fdl=0:fdc=1:ts=2:sw=2:sts=2

--- a/autoload/ctrlp/line.vim
+++ b/autoload/ctrlp/line.vim
@@ -80,7 +80,9 @@ endf
 "}}}
 
 fu! ctrlp#line#event(etype, ectx)
-	echom a:etype
+	if a:etype == 'init'
+		call timer_start(2000, {t->ctrlp#exit()})
+  endif
 endf
 
 " vim:fen:fdm=marker:fmr={{{,}}}:fdl=0:fdc=1:ts=2:sw=2:sts=2

--- a/autoload/ctrlp/line.vim
+++ b/autoload/ctrlp/line.vim
@@ -12,7 +12,7 @@ let g:loaded_ctrlp_line = 1
 
 cal add(g:ctrlp_ext_vars, {
 	\ 'init': 'ctrlp#line#init(s:crbufnr)',
-	\ 'event': 'ctrlp#line#event(s:etype, s:ectx)',
+	\ 'change': 'ctrlp#line#change()',
 	\ 'accept': 'ctrlp#line#accept',
 	\ 'act_farg' : 'dict',
 	\ 'lname': 'lines',
@@ -79,10 +79,13 @@ fu! ctrlp#line#cmd(mode, ...)
 endf
 "}}}
 
-fu! ctrlp#line#event(etype, ectx)
-	if a:etype == 'init'
-		call timer_start(2000, {t->ctrlp#exit()})
-  endif
+let s:i = 0
+fu! ctrlp#line#change()
+	let s:i += 1
+	echom s:i . ' ' . ctrlp#input()
+	if s:i == 10
+		call ctrlp#exit()
+	en
 endf
 
 " vim:fen:fdm=marker:fmr={{{,}}}:fdl=0:fdc=1:ts=2:sw=2:sts=2


### PR DESCRIPTION
This is a PR to solve the issue I mentioned at https://github.com/ctrlpvim/ctrlp.vim/issues/200. The idea comes from [quickpick.vim](https://github.com/prabirshrestha/quickpick.vim)

You can find a working example here. https://github.com/prabirshrestha/vim-lsp/pull/826

This requires changes to ctrlp. View demo at https://asciinema.org/a/333925.

![ctrlp-vim-lsp](https://user-images.githubusercontent.com/287744/82848844-3213aa80-9eaa-11ea-833d-d8c535aa585f.gif)

Most of the heavy lifting is already done via lsp servers so it is very fast and responsive.

- [x] `ctrlp#input` to get the current search term
- [x] `change` event to listen to the change in search term
- [x] `ctrlp#set(lines)` to set the lines. to clear use `ctrl#set([])`
- [x] `ctrlp#get()` to get the lines
- [x] `ctrlp#update()` to force re-render once you set.
- [ ] implement `user_data` for `set` so in accepts can get the value and do something with it.  I'm thinking more of this where we can set an array of objects and then instead have `get_line_text` function which return `item.label`. And we would also need to make sure that the `accept` takes in the entire object instead of just str.

```vim
call ctrlp#set([{ 'label': 'hello' }])
```

- [ ] implement busy indicator. using `ctrlp#busy(1)`
- [ ] update docs to reflect the new apis.


