### PR TITLE
Restore line prefix

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1739,7 +1739,7 @@ fu! s:formatline(str)
 	retu s:lineprefix.( cond ? s:pathshorten(str) : str )
 endf
 
-fu! s:formatline2(ct, str)
+fu! s:formatline2(ct, key, str)
 	let str = a:str
 	if a:ct == 'buf'
 		let bufnr = s:bufnrfilpath(str)[0]


### PR DESCRIPTION
I restored the line prefix ;)

### Before
<img width="363" alt="before" src="https://user-images.githubusercontent.com/64692680/98799933-19488280-2453-11eb-9761-af8a427b5407.png">

### After
<img width="360" alt="after" src="https://user-images.githubusercontent.com/64692680/98800081-3da45f00-2453-11eb-9489-3f7484172ef3.png">
