### PR TITLE
Add alacritty to terminals with keycode fixes

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1094,7 +1094,7 @@ fu! s:MapSpecs()
 	if !( exists('s:smapped') && s:smapped == s:bufnr )
 		" Correct arrow keys in terminal
 		if ( has('termresponse') && v:termresponse =~ "\<ESC>" )
-			\ || &term =~? '\vxterm|<k?vt|gnome|screen|linux|ansi|tmux|st(-[-a-z0-9]*)?(\:tc)?$'
+			\ || &term =~? '\vxterm|<k?vt|gnome|screen|linux|ansi|tmux|alacritty|st(-[-a-z0-9]*)?(\:tc)?$'
 			for each in ['\A <up>','\B <down>','\C <right>','\D <left>']
 				exe s:lcmap.' <esc>['.each
 			endfo


### PR DESCRIPTION
Fixes arrow keys, \<F5\>, and possibly others for the [Alacritty terminal](https://github.com/alacritty/alacritty).

Fixes #534 (when using Alacritty).