### PR TITLE
Fix redraw with ctrlp_key_loop = 1

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1386,6 +1386,7 @@ fu! s:MarkToOpen()
 		en
 	en
 	sil! cal ctrlp#statusline()
+	redr
 endf
 
 fu! s:OpenMulti(...)


### PR DESCRIPTION
When using ctrlp_key_loop = 1, `CTRL-Z` does not redraw screen.