### PR TITLE
Optimize s:Render()

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -751,6 +751,9 @@ fu! s:Render(lines, pat)
 	en
 	if s:mw_order == 'btt' | cal reverse(lines) | en
 	let s:lines = copy(lines)
+	if len(lines) > height
+		let lines = lines[:height]
+	en
 	if has('patch-8.1-0') && s:flfunc ==# 's:formatline(v:val)'
 		cal map(lines, function('s:formatline2', [s:curtype()]))
 	el


### PR DESCRIPTION
As far as I can see the code of s:Render(), many `lines` should be possible to be omitted over the height.

@tacahiroy Could you please review this?

If my analysis is correct, we will get great performance improvements. Below is demo under the directory which have 155732 files.

![screenshot](https://user-images.githubusercontent.com/10111/158630382-8059693d-2d00-476b-a103-6778d80541fe.gif)
