### PR TITLE
Improve CtrlP fuzzy finding results on large directories

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -95,7 +95,7 @@ let [s:pref, s:bpref, s:opts, s:new_opts, s:lc_opts] =
 	\ 'brief_prompt':          ['s:brfprt', 0],
 	\ 'match_current_file':    ['s:matchcrfile', 0],
 	\ 'match_natural_name':    ['s:matchnatural', 0],
-	\ 'compare_lim':           ['s:compare_lim', 3000],
+	\ 'compare_lim':           ['s:compare_lim', 0],
 	\ 'bufname_mod':           ['s:bufname_mod', ':t'],
 	\ 'bufpath_mod':           ['s:bufpath_mod', ':~:.:h'],
 	\ 'formatline_func':       ['s:flfunc', 's:formatline(v:val)'],
@@ -396,7 +396,7 @@ fu! ctrlp#files()
 		en
 		" Remove base directory
 		cal ctrlp#rmbasedir(g:ctrlp_allfiles)
-		if len(g:ctrlp_allfiles) <= s:compare_lim
+		if !s:compare_lim || len(g:ctrlp_allfiles) <= s:compare_lim
 			cal sort(g:ctrlp_allfiles, 'ctrlp#complen')
 		en
 		cal s:writecache(cafile)

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -847,6 +847,17 @@ Example: >
 
 This is possible to change no-limit mode for match type "path".
 
+                                                          *ctrlp_compare_lim*
+If your search directory has more number of files than this limit, no sorting
+will be performed for the first readout. You can improve CtrlP performance by
+setting this to a proper value, but no sorting on the first readout can reduce
+the quality of fuzzy finding results.
+Example:
+  let g:ctrlp_compare_lim = 100
+
+Set the value to 0 for unlimited sorting. Default is 0.  
+
+
 ===============================================================================
 COMMANDS                                                       *ctrlp-commands*
 


### PR DESCRIPTION
Issue: https://github.com/ctrlpvim/ctrlp.vim/issues/600

I find that for large directory, CtrlP is not ranking results with the best candidate. This causes by a limit on the number of files it will sort. It will not sort the first readout if limit is set and director has more than limit number of files. This PR is to set `unlimit` sorting by default but users can custom the limit value to improve CtrlP performance on large directory.

