### PR TITLE
Omit lines for reader

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -756,8 +756,8 @@ fu! s:Render(lines, pat)
 	en
 	if s:mw_order == 'btt' | cal reverse(lines) | en
 	let s:lines = copy(lines)
-	if s:maxfiles && len(lines) > s:maxfiles
-		let lines = lines[:s:maxfiles]
+	if s:nolim == 0 && len(lines) > height
+		let lines = lines[:height-1]
 	en
 	if has('patch-8.1-0') && s:flfunc ==# 's:formatline(v:val)'
 		cal map(lines, function('s:formatline2', [s:curtype()]))


### PR DESCRIPTION
https://github.com/ctrlpvim/ctrlp.vim/pull/597

So, CtrlP always be possible toomit lines if nolim is false. Now CtrlP get faster! YAY
