### PR TITLE
Add permanent cache for runtime scripts

### DIFF
--- a/autoload/ctrlp/rtscript.vim
+++ b/autoload/ctrlp/rtscript.vim
@@ -8,10 +8,10 @@
 if exists('g:loaded_ctrlp_rtscript') && g:loaded_ctrlp_rtscript
 	fini
 en
-let [g:loaded_ctrlp_rtscript, g:ctrlp_newrts] = [1, 0]
+let g:loaded_ctrlp_rtscript = 1
 
 cal add(g:ctrlp_ext_vars, {
-	\ 'init': 'ctrlp#rtscript#init(s:caching)',
+	\ 'init': 'ctrlp#rtscript#init()',
 	\ 'accept': 'ctrlp#acceptfile',
 	\ 'lname': 'runtime scripts',
 	\ 'sname': 'rts',
@@ -20,39 +20,46 @@ cal add(g:ctrlp_ext_vars, {
 	\ })
 
 let s:id = g:ctrlp_builtins + len(g:ctrlp_ext_vars)
-
-let s:filecounts = {}
 " Utilities {{{1
-fu! s:nocache()
-	retu g:ctrlp_newrts ||
-		\ !s:caching || ( s:caching > 1 && get(s:filecounts, s:cwd) < s:caching )
+fu! s:savetofile(rtss)
+	cal ctrlp#utils#writecache(a:rtss, s:cadir, s:cafile)
 endf
 " Public {{{1
-fu! ctrlp#rtscript#init(caching)
-	let [s:caching, s:cwd] = [a:caching, getcwd()]
-	if s:nocache() ||
-		\ !( exists('g:ctrlp_rtscache') && g:ctrlp_rtscache[0] == &rtp )
-		sil! cal ctrlp#progress('Indexing...')
-		let entries = split(globpath(ctrlp#utils#fnesc(&rtp, 'g'), '**/*.*'), "\n")
-		cal filter(entries, 'count(entries, v:val) == 1')
-		let [entries, echoed] = [ctrlp#dirnfile(entries)[1], 1]
+fu! ctrlp#rtscript#init()
+	let s:cwd = getcwd()
+	if !exists('g:ctrlp_rtscache')
+		let entries = ctrlp#utils#readfile(ctrlp#rtscript#cachefile())
+		" This should be cached as well after first run.
+		sil! cal ctrlp#progress('Processing...')
+		let results = map(copy(entries), 'fnamemodify(v:val, '':.'')')
+		let g:ctrlp_rtscache = [&rtp, s:cwd, entries, results]
 	el
 		let [entries, results] = g:ctrlp_rtscache[2:3]
 	en
-	if s:nocache() ||
-		\ !( exists('g:ctrlp_rtscache') && g:ctrlp_rtscache[:1] == [&rtp, s:cwd] )
-		if !exists('echoed')
-			sil! cal ctrlp#progress('Processing...')
-		en
-		let results = map(copy(entries), 'fnamemodify(v:val, '':.'')')
-	en
-	let [g:ctrlp_rtscache, g:ctrlp_newrts] = [[&rtp, s:cwd, entries, results], 0]
-	cal extend(s:filecounts, { s:cwd : len(results) })
 	retu results
 endf
 
 fu! ctrlp#rtscript#id()
 	retu s:id
+endf
+
+" Returns the cache file for runtime scripts.
+" If it doesn't exst then generate it
+fu! ctrlp#rtscript#cachefile()
+	if !exists('s:cadir') || !exists('s:cafile')
+		let s:cadir = ctrlp#utils#cachedir().ctrlp#utils#lash().'runtime'
+		let s:cafile = s:cadir.ctrlp#utils#lash().'cache.txt'
+	en
+
+	if !isdirectory(s:cadir) || !filereadable(s:cafile)
+		sil! cal ctrlp#progress('Indexing...')
+		let entries = split(globpath(ctrlp#utils#fnesc(&rtp, 'g'), '**/*.*'), "\n")
+		cal filter(entries, 'count(entries, v:val) == 1')
+		let entries = ctrlp#dirnfile(entries)[1]
+		cal s:savetofile(entries)
+	en
+
+	retu s:cafile
 endf
 "}}}
 


### PR DESCRIPTION
I have to wait a few seconds everytime I load the runtime script menu. This is cached afterward, but there should be a more permenant cache on the filesystem that saves all the paths similar to what MRU mode has. Fixes #609 
This isn't perfect; it could use more code reuse, but I'm very happy with it.

Unfortunately it doesn't work with the clear cache command. It works for MRU because it's a completely different type from files. If you need to refresh this cache just delete it manually.