### PR TITLE
Ensure the 'cst' option is available before referencing it.

### DIFF
--- a/autoload/ctrlp/tag.vim
+++ b/autoload/ctrlp/tag.vim
@@ -116,10 +116,14 @@ fu! ctrlp#tag#accept(mode, str)
 		if cmd != ''
 			exe cmd
 		en
-		let save_cst = &cst
-		set cst&
+		if exists('&cst')
+			let save_cst = &cst
+			set cst&
+		en
 		cal feedkeys(":".( utg ? fdcnt[2] : "" )."ta ".tg."\r", 'nt')
-		let &cst = save_cst
+		if exists('&cst')
+			let &cst = save_cst
+		en
 	el
 		let ext = ""
 		if fdcnt[1] < 2 && fdcnt[2]


### PR DESCRIPTION
Note that in Neovim the 'cst' ('cscopetag') option has been removed.