### PR TITLE
Silence `winc p` so Vim doesn't beep when opening a file

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1061,7 +1061,7 @@ fu! s:PrtExit()
 	exe bufwinnr(s:bufnr).'winc w'
 	if bufnr('%') == s:bufnr && bufname('%') == 'ControlP'
 		noa cal s:Close()
-		noa winc p
+		sil! noa winc p
 	els
 		exe bw.'winc w'
 	en


### PR DESCRIPTION
As of a recent patch of Vim, CtrlP causes a beep when it opens a new file (described in this Vim issue: https://github.com/vim/vim/issues/14047). Other uses of `winc p` are already protected by `sil!`.