### PR TITLE
Reflect "g:ctrlp_match_current_file" in CtrlPMRUFiles even when using "g:ctrlp_match_func"

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -641,6 +641,9 @@ fu! ctrlp#buffers(...)
 		retu ids
 	el
 		let bufs = [[], []]
+		if s:matcher != {} && !s:matchcrfile
+			call filter(ids, 'v:val != s:crbufnr')
+		en
 		for id in ids
 			let bname = bufname(id)
 			let ebname = bname == ''
@@ -2179,7 +2182,7 @@ fu! s:isabs(path)
 endf
 
 fu! s:bufnrfilpath(line)
-  if s:isabs(a:line) || a:line =~ '^\~[/\\]' || a:line =~ '^\w\+:\/\/'
+	if s:isabs(a:line) || a:line =~ '^\~[/\\]' || a:line =~ '^\w\+:\/\/'
 		let filpath = a:line
 	el
 		let filpath = s:dyncwd.s:lash().a:line

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -98,7 +98,6 @@ let [s:pref, s:bpref, s:opts, s:new_opts, s:lc_opts] =
 	\ 'compare_lim':           ['s:compare_lim', 0],
 	\ 'bufname_mod':           ['s:bufname_mod', ':t'],
 	\ 'bufpath_mod':           ['s:bufpath_mod', ':~:.:h'],
-	\ 'bufcurfile_filter':     ['s:bufcurfile_filter', 0],
 	\ 'formatline_func':       ['s:flfunc', 's:formatline(v:val)'],
 	\ 'user_command_async':    ['s:usrcmdasync', 0],
 	\ }, {
@@ -642,9 +641,6 @@ fu! ctrlp#buffers(...)
 		retu ids
 	el
 		let bufs = [[], []]
-		if s:bufcurfile_filter
-			call filter(ids, 'v:val != s:crbufnr')
-		en
 		for id in ids
 			let bname = bufname(id)
 			let ebname = bname == ''

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -98,6 +98,7 @@ let [s:pref, s:bpref, s:opts, s:new_opts, s:lc_opts] =
 	\ 'compare_lim':           ['s:compare_lim', 0],
 	\ 'bufname_mod':           ['s:bufname_mod', ':t'],
 	\ 'bufpath_mod':           ['s:bufpath_mod', ':~:.:h'],
+	\ 'bufcurfile_filter':     ['s:bufcurfile_filter', 0],
 	\ 'formatline_func':       ['s:flfunc', 's:formatline(v:val)'],
 	\ 'user_command_async':    ['s:usrcmdasync', 0],
 	\ }, {
@@ -641,6 +642,9 @@ fu! ctrlp#buffers(...)
 		retu ids
 	el
 		let bufs = [[], []]
+		if s:bufcurfile_filter
+			call filter(ids, 'v:val != s:crbufnr')
+		en
 		for id in ids
 			let bname = bufname(id)
 			let ebname = bname == ''

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -449,7 +449,8 @@ Includes the current file in the match entries: >
 
 By default, the current file is excluded from the list.
 
-Note: does not apply when |g:ctrlp_match_func| is used.
+Note: With the exception of |:CtrlPMRU|, does not apply when
+|g:ctrlp_match_func| is used.
 
                                                               *'g:ctrlp_types'*
 Set this to list of names to customize core types: >


### PR DESCRIPTION
Would it be useful to add an option to CtrlPBuffer to hide the current buffer?
Documentation has not yet been updated.