### PR TITLE
Fix readdir patch feature check

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -429,7 +429,7 @@ fu! s:CloseCustomFuncs()
 	en
 endf
 
-if has('patch-8.2-0995') && get(g:, 'ctrlp_use_readdir', 1)
+if has('patch-8.2.0995') && get(g:, 'ctrlp_use_readdir', 1)
 	fu! s:GlobPath(dirs, depth)
 		let entries = []
 		let dirs = substitute(a:dirs, '\\\([%# ]\)', '\1', 'g')


### PR DESCRIPTION
## Problem

The feature check guarding the `readdir()` file collector uses an invalid
patch-version format:

```vim
has('patch-8.2-0995')
```

Vim expects dots between the version and patch components. Consequently, this
check evaluates to false even on supported Vim versions, and CtrlP always uses
the `globpath()` fallback.

On macOS, `globpath()` can behave incorrectly when the working directory
contains a decomposed Unicode character. For example, with `o` followed by a
combining macron in the path, it returned an incomplete file list and normalized
the returned paths differently from `getcwd()`. This left CtrlP with no useful
file candidates for find-file searches.

The normalization difference can also prevent `ctrlp#rmbasedir()` from removing
the working-directory prefix because its comparison is byte-exact.

## Fix

Use the patch-version syntax recognized by Vim:

```vim
has('patch-8.2.0995')
```

This enables CtrlP's existing `readdir()` implementation on Vim versions that
support the required API. `readdir()` preserves the path representation during
traversal and returns the complete file list.

The existing fallback remains unchanged for older Vim versions and for users
who explicitly disable `g:ctrlp_use_readdir`.

## Testing

Tested with Vim 9.2 on macOS from a directory containing a decomposed Unicode
character.

Before the change:

- `has('patch-8.2-0995')` returned `0`.
- CtrlP used `globpath()`.
- Only one absolute file candidate was indexed.
- Find-file searches could not locate the project files.

After the change:

- `has('patch-8.2.0995')` returned `1`.
- CtrlP used `readdir()`.
- The complete relative candidate list was indexed.
- `:CtrlP` successfully found the project files.